### PR TITLE
fix: no panic if i.reader.Next() returns an empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.3.0 [unreleased]
 
+### Bug Fixes
+
+1. [#37](https://github.com/InfluxCommunity/influxdb3-go/pull/37): `runtime error` for iterating Arrow Record without rows
+
 ## 0.2.0 [2023-08-11]
 
 ### Features

--- a/influxdb3/query_iterator.go
+++ b/influxdb3/query_iterator.go
@@ -67,19 +67,12 @@ func (i *QueryIterator) Next() bool {
 	}
 	i.indexInRecord++
 	i.i++
-	if i.record == nil || i.indexInRecord >= int(i.record.NumRows()) {
+	for i.record == nil || i.indexInRecord >= int(i.record.NumRows()) {
 		if !i.reader.Next() {
 			i.done = true
 			return false
 		}
 		i.record = i.reader.Record()
-		for i.record.NumRows() == 0 {
-			if !i.reader.Next() {
-				i.done = true
-				return false
-			}
-			i.record = i.reader.Record()
-		}
 		i.indexInRecord = 0
 	}
 

--- a/influxdb3/query_iterator.go
+++ b/influxdb3/query_iterator.go
@@ -73,6 +73,13 @@ func (i *QueryIterator) Next() bool {
 			return false
 		}
 		i.record = i.reader.Record()
+		for i.record.NumRows() == 0 {
+			if !i.reader.Next() {
+				i.done = true
+				return false
+			}
+			i.record = i.reader.Record()
+		}
 		i.indexInRecord = 0
 	}
 

--- a/influxdb3/query_iterator_test.go
+++ b/influxdb3/query_iterator_test.go
@@ -1,0 +1,63 @@
+package influxdb3
+
+import (
+	"bytes"
+	"github.com/apache/arrow/go/v13/arrow"
+	"github.com/apache/arrow/go/v13/arrow/array"
+	"github.com/apache/arrow/go/v13/arrow/flight"
+	"github.com/apache/arrow/go/v13/arrow/ipc"
+	"github.com/apache/arrow/go/v13/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type testMessagesReader struct {
+	r ipc.MessageReader
+}
+
+func (r *testMessagesReader) Message() (*ipc.Message, error) {
+	return r.r.Message()
+}
+func (r *testMessagesReader) Release() {}
+func (r *testMessagesReader) Retain()  {}
+
+func TestQueryIteratorEmptyRecord(t *testing.T) {
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "f1", Type: arrow.PrimitiveTypes.Int32},
+	}, nil)
+	var buf bytes.Buffer
+	writer := ipc.NewWriter(&buf, ipc.WithSchema(schema))
+
+	rb := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	rec := rb.NewRecord() // first record is empty
+	err := writer.Write(rec)
+	assert.Nil(t, err)
+
+	rb.Field(0).(*array.Int32Builder).AppendValues([]int32{1}, nil)
+	rec = rb.NewRecord() // second record is not empty
+	err = writer.Write(rec)
+	assert.Nil(t, err)
+
+	err = writer.Close()
+	assert.Nil(t, err)
+
+	reader := ipc.NewMessageReader(&buf)
+
+	ipcReader, err := ipc.NewReaderFromMessageReader(
+		&testMessagesReader{
+			r: reader,
+		})
+	assert.Nil(t, err)
+
+	fReader := &flight.Reader{Reader: ipcReader}
+	it := newQueryIterator(fReader)
+
+	count := 0
+	for it.Next() {
+		assert.Equal(t, 1, it.record.Column(0).(*array.Int32).Len())
+		assert.Equal(t, int32(1), it.record.Column(0).(*array.Int32).Value(0))
+		assert.Equal(t, 0, count)
+		count++
+	}
+	assert.Equal(t, 1, count)
+}


### PR DESCRIPTION
## Proposed Changes

fix for bug if reader.Next returns an empty result. 
Now it results in panic:
```
panic: runtime error: index out of range [0] with length 0

goroutine 424 [running]:
github.com/apache/arrow/go/v12/arrow/array.(*String).Value(...)
	/go/pkg/mod/github.com/apache/arrow/go/v12@v12.0.0/arrow/array/string.go:54
github.com/InfluxCommunity/influxdb3-go/influx.getArrowValue({0x18e4ed0, 0xc000e44aa0}, 0x0)
	/go/pkg/mod/github.com/!influx!community/influxdb3-go@v0.1.0/influx/query_iterator.go:139 +0x1085
github.com/InfluxCommunity/influxdb3-go/influx.(*QueryIterator).Next(0xc000aa62c0)
	/go/pkg/mod/github.com/!influx!community/influxdb3-go@v0.1.0/influx/query_iterator.go:62 +0x205
```
## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
