### PR TITLE
feat: type-safe conversion for line-protocol Addfield #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.4.0 [unreleased]
 
+### Features
+
+1. [#42](https://github.com/InfluxCommunity/influxdb3-go/pull/42): Add type-safe conversion for line-protocol
+
 ## 0.3.0 [2023-10-02]
 
 ### Features

--- a/influxdb3/example_test.go
+++ b/influxdb3/example_test.go
@@ -1,0 +1,50 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/line-protocol/v2/lineprotocol"
+)
+
+func ExamplePoint_AddFieldFromValue() {
+	p := NewPoint("measurement", map[string]string{}, map[string]interface{}{}, time.Now())
+	p.AddFieldFromValue("hello", NewValueFromString("world"))
+	p.AddFieldFromValue("float", NewValueFromFloat(55.101))
+	p.AddFieldFromValue("time.Time", NewValueFromTime(time.Date(2020, time.March, 20, 10, 30, 23, 123456789, time.UTC)))
+	p.SetTimestamp(time.Date(2020, time.March, 20, 10, 30, 23, 123456789, time.UTC))
+	line, _ := p.MarshalBinary(lineprotocol.Nanosecond)
+	fmt.Println(string(line))
+	// Output: measurement float=55.101,hello="world",time.Time="2020-03-20T10:30:23.123456789Z" 1584700223123456789
+}
+
+func ExampleNewValueFromStringer() {
+	p := NewPoint("measurement", map[string]string{}, map[string]interface{}{}, time.Now())
+	p.AddFieldFromValue("Supports time.Duration", NewValueFromStringer(4*time.Hour))
+	p.SetTimestamp(time.Date(2020, time.March, 20, 10, 30, 23, 123456789, time.UTC))
+	line, _ := p.MarshalBinary(lineprotocol.Nanosecond)
+	fmt.Println(string(line))
+	// Output: measurement Supports\ time.Duration="4h0m0s" 1584700223123456789
+}

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -155,7 +155,7 @@ func (m *Point) AddField(k string, v interface{}) *Point {
 	return m
 }
 
-// AddFieldFromValue adds a [github.com/influxdata/line-protocol/v2/lineprotocol.Value] to the Point.
+// AddFieldFromValue adds a [lineprotocol.Value] to the Point.
 //
 // Parameters:
 //   - k: The key of the field.
@@ -163,6 +163,8 @@ func (m *Point) AddField(k string, v interface{}) *Point {
 //
 // Returns:
 //   - The updated Point with the field added.
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
 func (m *Point) AddFieldFromValue(k string, v lineprotocol.Value) *Point {
 	for i, field := range m.Fields {
 		if k == field.Key {

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -155,6 +155,26 @@ func (m *Point) AddField(k string, v interface{}) *Point {
 	return m
 }
 
+// AddFieldFromValue adds a [github.com/influxdata/line-protocol/v2/lineprotocol.Value] to the Point.
+//
+// Parameters:
+//   - k: The key of the field.
+//   - v: The value of the line protocol format.
+//
+// Returns:
+//   - The updated Point with the field added.
+func (m *Point) AddFieldFromValue(k string, v lineprotocol.Value) *Point {
+	for i, field := range m.Fields {
+		if k == field.Key {
+			m.Fields[i].Value = v
+			return m
+		}
+	}
+
+	m.Fields = append(m.Fields, Field{Key: k, Value: v})
+	return m
+}
+
 // AddField adds a field to the Point.
 //
 // Parameters:

--- a/influxdb3/point_test.go
+++ b/influxdb3/point_test.go
@@ -178,31 +178,3 @@ func TestAddFieldFromValue(t *testing.T) {
 	assert.PanicsWithError(t, "invalid float value for NewValueFromFloat: float64 (-Inf)", func() { NewValueFromFloat(math.Inf(-1)) })
 	assert.PanicsWithError(t, "invalid utf-8 string value for NewValueFromString: string (\"\\xed\\x9f\\xc1\")", func() { NewValueFromString(string([]byte{237, 159, 193})) })
 }
-
-func TestNewValueFromNative(t *testing.T) {
-	p := NewPoint(
-		"test",
-		map[string]string{
-			"id":        "10ad=",
-			"ven=dor":   "AWS",
-			`host"name`: `ho\st "a"`,
-			`x\" x`:     "a b",
-		},
-		map[string]interface{}{},
-		time.Unix(60, 70))
-
-	p.AddFieldFromValue("float64", NewValueFromNative(80.1234567))
-	p.AddFieldFromValue("int64", NewValueFromNative(int64(-1234567890)))
-	p.AddFieldFromValue("uint64", NewValueFromNative(uint64(12345677890)))
-	p.AddFieldFromValue("string", NewValueFromNative(`six, "seven", eight`))
-	p.AddFieldFromValue("bytes", NewValueFromNative([]byte(`six=seven\, eight`)))
-	p.AddFieldFromValue("bool", NewValueFromNative(false))
-
-	line, err := p.MarshalBinary(lineprotocol.Nanosecond)
-	require.NoError(t, err)
-	assert.EqualValues(t, `test,host"name=ho\st\ "a",id=10ad\=,ven\=dor=AWS,x\"\ x=a\ b bool=false,bytes="six=seven\\, eight",float64=80.1234567,int64=-1234567890i,string="six, \"seven\", eight",uint64=12345677890u 60000000070`+"\n", string(line))
-
-	assert.PanicsWithError(t, "invalid value for NewValue: float64 (+Inf)", func() { NewValueFromNative(math.Inf(1)) })
-	assert.PanicsWithError(t, "invalid value for NewValue: float64 (-Inf)", func() { NewValueFromNative(math.Inf(-1)) })
-	assert.PanicsWithError(t, "invalid value for NewValue: string (\"\\xed\\x9f\\xc1\")", func() { NewValueFromNative(string([]byte{237, 159, 193})) })
-}

--- a/influxdb3/value.go
+++ b/influxdb3/value.go
@@ -32,8 +32,6 @@ import (
 // NativeType are unions of type sets that can converted to [lineprotocol.NewValue].
 //
 // [lineprotocol.NewValue]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#NewValue
-//
-// [line-protocol]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#field-set
 type NativeType interface {
 	float64 | int64 | uint64 | string | []byte | bool
 }
@@ -148,10 +146,10 @@ func NewValueFromString[S String](v S) lineprotocol.Value {
 	return data
 }
 
-// NewValueFromUInt is a convenient function for creating a [lineprotocol.Value] from [fmt.Stringer].
+// NewValueFromStringer is a convenient function for creating a [lineprotocol.Value] from [fmt.Stringer].
 //
 // Parameters:
-//   - v: The value of the UInteger value.
+//   - v: The value of the [fmt.Stringer] value.
 //
 // Returns:
 //   - The created [lineprotocol.Value].
@@ -174,7 +172,7 @@ func NewValueFromBoolean[B Boolean](v B) lineprotocol.Value {
 	return lineprotocol.BoolValue(bool(v))
 }
 
-// NewValueFromBoolean is a convenient function for creating a [lineprotocol.Value] from [time.Time].
+// NewValueFromTime is a convenient function for creating a [lineprotocol.Value] from [time.Time].
 //
 // Parameters:
 //   - v: The value of the [time.Time] value.

--- a/influxdb3/value.go
+++ b/influxdb3/value.go
@@ -39,7 +39,6 @@ type NativeType interface {
 }
 
 // [Float] is IEEE-754 64-bit floating-point numbers. Default numerical type. InfluxDB supports scientific notation in float field values.
-// Non-finite floating-point field values (+/- infinity and NaN from IEEE 754) are not currently supported.
 //
 // [Float]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#float
 type Float interface {
@@ -88,6 +87,7 @@ func NewValueFromNative[N NativeType](v N) lineprotocol.Value {
 }
 
 // NewValueFromFloat is a convenient function for creating a [lineprotocol.Value] from Float.
+// Non-finite floating-point field values (+/- infinity and NaN from IEEE 754) are not currently supported.
 //
 // Parameters:
 //   - v: The value of the Float value.
@@ -131,6 +131,7 @@ func NewValueFromUInt[U UInteger](v U) lineprotocol.Value {
 }
 
 // NewValueFromString is a convenient function for creating a [lineprotocol.Value] from String.
+// Non-UTF-8 string field values are not currently supported.
 //
 // Parameters:
 //   - v: The value of the String value.
@@ -148,13 +149,6 @@ func NewValueFromString[S String](v S) lineprotocol.Value {
 }
 
 // NewValueFromUInt is a convenient function for creating a [lineprotocol.Value] from [fmt.Stringer].
-//
-// Examples:
-//
-//	func example() {
-//		p := NewPoint("measurement", map[string]string{}, map[string]interface{}{}, time.Now())
-//		p.AddFieldFromValue("supports time.Duration", NewValueFromStringer(4*time.Hour))
-//	}
 //
 // Parameters:
 //   - v: The value of the UInteger value.

--- a/influxdb3/value.go
+++ b/influxdb3/value.go
@@ -36,35 +36,35 @@ type NativeType interface {
 	float64 | int64 | uint64 | string | []byte | bool
 }
 
-// [Float] is IEEE-754 64-bit floating-point numbers. Default numerical type. InfluxDB supports scientific notation in float field values.
+// Float [Float] is IEEE-754 64-bit floating-point numbers. Default numerical type. InfluxDB supports scientific notation in float field values.
 //
 // [Float]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#float
 type Float interface {
 	~float32 | ~float64
 }
 
-// [Integer] is signed 64-bit integers.
+// Integer [Integer] is signed 64-bit integers.
 //
 // [Integer]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#integer
 type Integer interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
-// [UInteger] is unsigned 64-bit integers.
+// UInteger [UInteger] is unsigned 64-bit integers.
 //
 // [UInteger]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#uinteger
 type UInteger interface {
 	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
 }
 
-// [String] is plain text string. Length limit 64KB.
+// String [String] is plain text string. Length limit 64KB.
 //
 // [String]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#string
 type String interface {
 	~string | ~[]byte
 }
 
-// [Boolean] is true or false values.
+// Boolean [Boolean] is true or false values.
 //
 // [Boolean]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#boolean
 type Boolean interface {

--- a/influxdb3/value.go
+++ b/influxdb3/value.go
@@ -1,0 +1,194 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/line-protocol/v2/lineprotocol"
+)
+
+// NativeType are unions of type sets that can converted to [lineprotocol.NewValue].
+//
+// [lineprotocol.NewValue]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#NewValue
+//
+// [line-protocol]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#field-set
+type NativeType interface {
+	float64 | int64 | uint64 | string | []byte | bool
+}
+
+// [Float] is IEEE-754 64-bit floating-point numbers. Default numerical type. InfluxDB supports scientific notation in float field values.
+// Non-finite floating-point field values (+/- infinity and NaN from IEEE 754) are not currently supported.
+//
+// [Float]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#float
+type Float interface {
+	~float32 | ~float64
+}
+
+// [Integer] is signed 64-bit integers.
+//
+// [Integer]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#integer
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// [UInteger] is unsigned 64-bit integers.
+//
+// [UInteger]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#uinteger
+type UInteger interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+// [String] is plain text string. Length limit 64KB.
+//
+// [String]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#string
+type String interface {
+	~string | ~[]byte
+}
+
+// [Boolean] is true or false values.
+//
+// [Boolean]: https://docs.influxdata.com/influxdb/cloud-serverless/reference/syntax/line-protocol/#boolean
+type Boolean interface {
+	~bool
+}
+
+// NewValueFromNative is a convenient function for creating a [lineprotocol.Value] from NativeType.
+//
+// Parameters:
+//   - v: The value of the field value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromNative[N NativeType](v N) lineprotocol.Value {
+	return lineprotocol.MustNewValue(v)
+}
+
+// NewValueFromFloat is a convenient function for creating a [lineprotocol.Value] from Float.
+//
+// Parameters:
+//   - v: The value of the Float value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromFloat[F Float](v F) lineprotocol.Value {
+	data, ok := lineprotocol.FloatValue(float64(v))
+	if !ok {
+		panic(fmt.Errorf("invalid float value for NewValueFromFloat: %T (%#v)", v, v))
+	}
+	return data
+}
+
+// NewValueFromInt is a convenient function for creating a [lineprotocol.Value] from Integer.
+//
+// Parameters:
+//   - v: The value of the Integer value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromInt[I Integer](v I) lineprotocol.Value {
+	return lineprotocol.IntValue(int64(v))
+}
+
+// NewValueFromUInt is a convenient function for creating a [lineprotocol.Value] from UInteger.
+//
+// Parameters:
+//   - v: The value of the UInteger value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromUInt[U UInteger](v U) lineprotocol.Value {
+	return lineprotocol.UintValue(uint64(v))
+}
+
+// NewValueFromString is a convenient function for creating a [lineprotocol.Value] from String.
+//
+// Parameters:
+//   - v: The value of the String value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromString[S String](v S) lineprotocol.Value {
+	data, ok := lineprotocol.StringValue(string(v))
+	if !ok {
+		panic(fmt.Errorf("invalid utf-8 string value for NewValueFromString: %T (%#v)", v, v))
+	}
+	return data
+}
+
+// NewValueFromUInt is a convenient function for creating a [lineprotocol.Value] from [fmt.Stringer].
+//
+// Examples:
+//
+//	func example() {
+//		p := NewPoint("measurement", map[string]string{}, map[string]interface{}{}, time.Now())
+//		p.AddFieldFromValue("supports time.Duration", NewValueFromStringer(4*time.Hour))
+//	}
+//
+// Parameters:
+//   - v: The value of the UInteger value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromStringer[S fmt.Stringer](v S) lineprotocol.Value {
+	return NewValueFromString(v.String())
+}
+
+// NewValueFromBoolean is a convenient function for creating a [lineprotocol.Value] from Boolean.
+//
+// Parameters:
+//   - v: The value of the Boolean value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromBoolean[B Boolean](v B) lineprotocol.Value {
+	return lineprotocol.BoolValue(bool(v))
+}
+
+// NewValueFromBoolean is a convenient function for creating a [lineprotocol.Value] from [time.Time].
+//
+// Parameters:
+//   - v: The value of the [time.Time] value.
+//
+// Returns:
+//   - The created [lineprotocol.Value].
+//
+// [lineprotocol.Value]: https://pkg.go.dev/github.com/influxdata/line-protocol/v2/lineprotocol#Value
+func NewValueFromTime(v time.Time) lineprotocol.Value {
+	return NewValueFromString(v.Format(time.RFC3339Nano))
+}

--- a/influxdb3/value_test.go
+++ b/influxdb3/value_test.go
@@ -1,0 +1,61 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/influxdata/line-protocol/v2/lineprotocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValueFromNative(t *testing.T) {
+	p := NewPoint(
+		"test",
+		map[string]string{
+			"id":        "10ad=",
+			"ven=dor":   "AWS",
+			`host"name`: `ho\st "a"`,
+			`x\" x`:     "a b",
+		},
+		map[string]interface{}{},
+		time.Unix(60, 70))
+
+	p.AddFieldFromValue("float64", NewValueFromNative(80.1234567))
+	p.AddFieldFromValue("int64", NewValueFromNative(int64(-1234567890)))
+	p.AddFieldFromValue("uint64", NewValueFromNative(uint64(12345677890)))
+	p.AddFieldFromValue("string", NewValueFromNative(`six, "seven", eight`))
+	p.AddFieldFromValue("bytes", NewValueFromNative([]byte(`six=seven\, eight`)))
+	p.AddFieldFromValue("bool", NewValueFromNative(false))
+
+	line, err := p.MarshalBinary(lineprotocol.Nanosecond)
+	require.NoError(t, err)
+	assert.EqualValues(t, `test,host"name=ho\st\ "a",id=10ad\=,ven\=dor=AWS,x\"\ x=a\ b bool=false,bytes="six=seven\\, eight",float64=80.1234567,int64=-1234567890i,string="six, \"seven\", eight",uint64=12345677890u 60000000070`+"\n", string(line))
+
+	assert.PanicsWithError(t, "invalid value for NewValue: float64 (+Inf)", func() { NewValueFromNative(math.Inf(1)) })
+	assert.PanicsWithError(t, "invalid value for NewValue: float64 (-Inf)", func() { NewValueFromNative(math.Inf(-1)) })
+	assert.PanicsWithError(t, "invalid value for NewValue: string (\"\\xed\\x9f\\xc1\")", func() { NewValueFromNative(string([]byte{237, 159, 193})) })
+}


### PR DESCRIPTION
- Closes #43
  - back to draft. in favor of #45.

## Proposed Changes

- Add line-protocol compliant wrapper
- Add generic type constraints
  - line-protocol type
    - Float
    - Integer
    - Uinteger
    - String
    - Bool
  - native go  <> line-protocol shortcut
  - `time.Time` conversion
  - `time.Duration` - using `fmt.Stringer`

```go
func (m *Point) AddFieldFromValue(k string, v lineprotocol.Value) *Point {}
func NewValueFromInt[I Integer](v I) lineprotocol.Value {}
```

### Usage

```go
func example() {
	p := NewPoint("measurement", map[string]string{}, map[string]interface{}{"measurement": "air"}, time.Now())
        // unsupported type.
	p.AddFieldFromValue("✅ Compile error.", cmplx.Inf())
        // supported type.
	p.AddFieldFromValue("✅ This is safe.", NewValueFromInt(255))
}
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
