### PR TITLE
fix: exports DefaultTags from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.6.0 [unreleased]
 
+### Bug Fixes
+
+1. [#59](https://github.com/InfluxCommunity/influxdb3-go/pull/59): Export Default Tags from package
+
 ## 0.5.0 [2023-12-05]
 
 ### Features

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -45,7 +45,7 @@ type WriteOptions struct {
 	Precision lineprotocol.Precision
 
 	// Tags added to each point during writing. If a point already has a tag with the same key, it is left unchanged.
-	// 
+	//
 	// Example using WritePointsWithOptions:
 	//  c, _ := New(ClientConfig{
 	//  	Host:         "host",
@@ -55,7 +55,7 @@ type WriteOptions struct {
 	//  })
 	//
 	//  options := WriteOptions{
-	//  	defaultTags: map[string]string{ 
+	//  	DefaultTags: map[string]string{
 	//  		"rack": "main",
 	//  	},
 	//  	Precision: lineprotocol.Millisecond,
@@ -74,7 +74,7 @@ type WriteOptions struct {
 	//  	Organization: "my-org",
 	//  	Database:     "my-database",
 	//  	WriteOptions: &WriteOptions{
-	//  		defaultTags: map[string]string{ 
+	//  		DefaultTags: map[string]string{
 	//  			"rack": "main",
 	//  		},
 	//  		Precision: lineprotocol.Millisecond,
@@ -86,7 +86,7 @@ type WriteOptions struct {
 	//
 	//  // Writes with rack=main tag
 	//  c.WritePoints(context.Background(), p)
-	defaultTags map[string]string
+	DefaultTags map[string]string
 
 	// Write body larger than the threshold is gzipped. 0 to don't gzip at all
 	GzipThreshold int

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -233,12 +233,11 @@ func (p *Point) MarshalBinary(precision lineprotocol.Precision) ([]byte, error) 
 	return p.MarshalBinaryWithDefaultTags(precision, nil)
 }
 
-
 // MarshalBinaryWithDefaultTags converts the Point to its binary representation in line protocol format with default tags.
 //
 // Parameters:
 //   - precision: The precision to use for timestamp encoding in line protocol format.
-//   - defaultTags: Tags added to each point during writing. If a point already has a tag with the same key, it is left unchanged.
+//   - DefaultTags: Tags added to each point during writing. If a point already has a tag with the same key, it is left unchanged.
 //
 // Returns:
 //   - The binary representation of the Point in line protocol format.
@@ -249,7 +248,7 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 	enc.StartLine(p.Values.MeasurementName)
 
 	// sort Tags
-	tagKeys := make([]string, 0, len(p.Values.Tags) + len(defaultTags))
+	tagKeys := make([]string, 0, len(p.Values.Tags)+len(defaultTags))
 	for k := range p.Values.Tags {
 		tagKeys = append(tagKeys, k)
 	}
@@ -265,9 +264,9 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 	}
 	for _, tagKey := range tagKeys {
 		if lastKey == tagKey {
-			continue;
+			continue
 		}
-		lastKey = tagKey;
+		lastKey = tagKey
 
 		if value, ok := p.Values.Tags[tagKey]; ok {
 			enc.AddTag(tagKey, value)

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -67,11 +67,11 @@ func (c *Client) WritePointsWithOptions(ctx context.Context, options *WriteOptio
 	} else {
 		precision = c.config.WriteOptions.Precision
 	}
-	var defaultTags map[string]string;
-	if options != nil && options.defaultTags != nil {
-		defaultTags = options.defaultTags;
+	var defaultTags map[string]string
+	if options != nil && options.DefaultTags != nil {
+		defaultTags = options.DefaultTags
 	} else {
-		defaultTags = c.config.WriteOptions.defaultTags;
+		defaultTags = c.config.WriteOptions.DefaultTags
 	}
 
 	for _, p := range points {
@@ -283,5 +283,5 @@ func encode(x interface{}, options *WriteOptions) ([]byte, error) {
 	if !point.HasFields() {
 		return nil, fmt.Errorf("no struct field with tag 'field'")
 	}
-	return point.MarshalBinaryWithDefaultTags(options.Precision, options.defaultTags)
+	return point.MarshalBinaryWithDefaultTags(options.Precision, options.DefaultTags)
 }

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -383,9 +383,9 @@ func TestWritePointsAndBytes(t *testing.T) {
 
 func TestWritePointsWithOptions(t *testing.T) {
 	points := genPoints(t, 1)
-	defaultTags := map[string]string{ 
+	defaultTags := map[string]string{
 		"defaultTag": "default",
-		"rack": "main",
+		"rack":       "main",
 	}
 	lp := points2bytes(t, points, defaultTags)
 	correctPath := "/api/v2/write?bucket=x-db&org=&precision=ms"
@@ -408,9 +408,9 @@ func TestWritePointsWithOptions(t *testing.T) {
 		Database: "my-database",
 	})
 	options := WriteOptions{
-		Database:  "x-db",
-		Precision: lineprotocol.Millisecond,
-		defaultTags: defaultTags,
+		Database:    "x-db",
+		Precision:   lineprotocol.Millisecond,
+		DefaultTags: defaultTags,
 	}
 	require.NoError(t, err)
 	err = c.WritePointsWithOptions(context.Background(), &options, points...)
@@ -500,7 +500,7 @@ func TestWriteDataWithOptions(t *testing.T) {
 	options := WriteOptions{
 		Database:  "x-db",
 		Precision: lineprotocol.Second,
-		defaultTags: map[string]string{ 
+		DefaultTags: map[string]string{
 			"defaultTag": "default",
 		},
 	}


### PR DESCRIPTION
Closes #

## Proposed Changes

While doing exploratory testing of the library, I discovered I could not access `defaultTags` in my local project.  

This changes the naming of `defaultTags` in `WriteOptions` to `DefaultTags` to make the field visible outside of the package.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
