### PR TITLE
refactor: rename `FlightSQL` constant to `SQL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,5 +57,5 @@ Renamed config types and some options.
 
 - initial release of new client version
 - write using v2 api
-- query using flightSQL
+- query using SQL
 - query using influxQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## 0.7.0 [unreleased]
 
+### Breaking Changes
+
+- Rename `FlightSQL` constant to `SQL`. You are able to easily migrate by:
+    ```diff
+      - queryOptions := QueryOptions{
+	  -   Database:  "my-db",
+	  -   QueryType: FlightSQL,
+      - }
+      + queryOptions := QueryOptions{
+	  +   Database:  "my-db",
+	  +   QueryType: SQL,
+      + }
+      ```
+  
+### Bug Fixes
+
+1. [#71](https://github.com/InfluxCommunity/influxdb3-go/pull/71): Rename `FlightSQL` constant to `SQL`
+
 ### Others
 
 1. [#68](https://github.com/InfluxCommunity/influxdb3-go/pull/68): Upgrade Go version to 1.22.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 ## 0.7.0 [unreleased]
 
-### Breaking Changes
-
-- Rename `FlightSQL` constant to `SQL`. You are able to easily migrate by:
-    ```diff
-      - queryOptions := QueryOptions{
-	  -   Database:  "my-db",
-	  -   QueryType: FlightSQL,
-      - }
-      + queryOptions := QueryOptions{
-	  +   Database:  "my-db",
-	  +   QueryType: SQL,
-      + }
-      ```
-  
 ### Bug Fixes
 
 1. [#71](https://github.com/InfluxCommunity/influxdb3-go/pull/71): Rename `FlightSQL` constant to `SQL`

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -94,7 +94,7 @@ type WriteOptions struct {
 
 // DefaultQueryOptions specifies default query options
 var DefaultQueryOptions = QueryOptions{
-	QueryType: FlightSQL,
+	QueryType: SQL,
 }
 
 // DefaultWriteOptions specifies default write options

--- a/influxdb3/query_type.go
+++ b/influxdb3/query_type.go
@@ -27,7 +27,7 @@ type QueryType int
 
 // QueryType constants
 const (
-	FlightSQL QueryType = iota
+	SQL QueryType = iota
 	InfluxQL
 )
 


### PR DESCRIPTION
Closes #70

## Proposed Changes

Rename `FlightSQL` constant to `SQL`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
