### PR TITLE
feat: add support for custom query/gRPC headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Others
 
 1. [#68](https://github.com/InfluxCommunity/influxdb3-go/pull/68): Upgrade Go version to 1.22.
+1. [#76](https://github.com/InfluxCommunity/influxdb3-go/pull/76): Add custom headers support for queries (gRPC requests)
 
 ## 0.6.0 [2024-03-01]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 1. [#68](https://github.com/InfluxCommunity/influxdb3-go/pull/68): Upgrade Go version to 1.22.
 2. [#74](https://github.com/InfluxCommunity/influxdb3-go/pull/74): Use `log/slog` to print debug information instead of `fmt.Printf`
-1. [#76](https://github.com/InfluxCommunity/influxdb3-go/pull/76): Add custom headers support for queries (gRPC requests)
+3. [#76](https://github.com/InfluxCommunity/influxdb3-go/pull/76): Add custom headers support for queries (gRPC requests)
 
 ## 0.6.0 [2024-03-01]
 

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -32,17 +32,11 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/apache/arrow/go/v15/arrow/flight"
 )
-
-// system headers
-var systemHeaders = []string{
-	"Authorization",
-}
 
 // Client implements an InfluxDB client.
 type Client struct {
@@ -246,11 +240,4 @@ func (c *Client) Close() error {
 	c.config.HTTPClient.CloseIdleConnections()
 	err := (*c.queryClient).Close()
 	return err
-}
-
-// isSystemHeader checks if header is used by the InfluxDB and cannot be set by user directly
-func (c *Client) isSystemHeader(key string) bool {
-	return slices.ContainsFunc(systemHeaders, func(s string) bool {
-		return strings.ToLower(s) == strings.ToLower(key)
-	})
 }

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -47,7 +47,7 @@ type Client struct {
 	// Cached base server API URL.
 	apiURL *url.URL
 	// Flight client for executing queries
-	queryClient *flight.Client
+	queryClient flight.Client
 }
 
 // httpParams holds parameters for creating an HTTP request
@@ -238,6 +238,6 @@ func (c *Client) resolveHTTPError(r *http.Response) error {
 // Close closes all idle connections.
 func (c *Client) Close() error {
 	c.config.HTTPClient.CloseIdleConnections()
-	err := (*c.queryClient).Close()
+	err := c.queryClient.Close()
 	return err
 }

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -27,7 +27,6 @@ package influxdb3_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -199,81 +198,6 @@ func TestQueryWithParameters(t *testing.T) {
 	time.Sleep(sleepTime)
 
 	iterator, err := client.QueryWithParameters(context.Background(), query, parameters)
-	require.NoError(t, err)
-	require.NotNil(t, iterator)
-
-	hasValue := iterator.Next()
-	assert.True(t, hasValue)
-
-	value := iterator.Value()
-	assert.Equal(t, "sun-valley-1", value["location"])
-	assert.Equal(t, 15.5, value["temp"])
-	assert.Equal(t, int64(80), value["index"])
-	assert.Equal(t, uint64(800), value["uindex"])
-	assert.Equal(t, true, value["valid"])
-	assert.Equal(t, "a1", value["text"])
-	assert.Equal(t, now, value["time"].(arrow.Timestamp).ToTime(arrow.Nanosecond))
-
-	assert.False(t, iterator.Done())
-	assert.False(t, iterator.Next())
-	assert.True(t, iterator.Done())
-}
-
-func TestQueryWithCustomHeaders(t *testing.T) {
-	now := time.Now().UTC()
-	testId := now.UnixNano()
-
-	url := os.Getenv("TESTING_INFLUXDB_URL")
-	token := os.Getenv("TESTING_INFLUXDB_TOKEN")
-	database := os.Getenv("TESTING_INFLUXDB_DATABASE")
-
-	client, err := influxdb3.New(influxdb3.ClientConfig{
-		Host:     url,
-		Token:    token,
-		Database: database,
-		Headers:  http.Header{
-			"X-client-config-header": {"client-config-1"},
-			"Authorization": {"Bearer x-client-config-fake-token"},
-		},
-	})
-	require.NoError(t, err)
-	defer client.Close()
-
-	tableName := "weather"
-	tagKey := "location"
-	tagValue := "sun-valley-1"
-
-	p := influxdb3.NewPointWithMeasurement("weather").
-		SetTag("location", "sun-valley-1").
-		SetField("temp", 15.5).
-		SetField("index", 80).
-		SetField("uindex", uint64(800)).
-		SetField("valid", true).
-		SetField("testId", testId).
-		SetField("text", "a1").
-		SetTimestamp(now)
-	err = client.WritePoints(context.Background(), []*influxdb3.Point{p})
-	require.NoError(t, err)
-
-	query := fmt.Sprintf(`
-		SELECT *
-		FROM "%s"
-		WHERE
-		time >= now() - interval '10 minute'
-		AND
-		"%s" = '%s'
-		AND
-		"testId" = %d
-		ORDER BY time
-	`, tableName, tagKey, tagValue, testId)
-
-	sleepTime := 5 * time.Second
-	time.Sleep(sleepTime)
-
-	iterator, err := client.Query(context.Background(), query,
-		influxdb3.WithHeader("X-method-header", "x-method-1"),
-		influxdb3.WithHeader("Authorization", "Bearer method-fake-token"), // system header, should be ignored
-	)
 	require.NoError(t, err)
 	require.NotNil(t, iterator)
 

--- a/influxdb3/example_query_test.go
+++ b/influxdb3/example_query_test.go
@@ -1,0 +1,84 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import (
+	"context"
+	"log"
+)
+
+func ExampleClient_Query() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// query
+	iterator, err := client.Query(context.Background(),
+		"SELECT count(*) FROM weather WHERE time >= now() - interval '5 minutes'")
+
+	for iterator.Next() {
+		// process the result
+	}
+
+	// query with custom header
+	iterator, err = client.Query(context.Background(),
+		"SELECT count(*) FROM stat WHERE time >= now() - interval '5 minutes'",
+		WithHeader("X-trace-ID", "#0122"))
+
+	for iterator.Next() {
+		// process the result
+	}
+}
+
+func ExampleClient_QueryWithParameters() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// query
+	iterator, err := client.QueryWithParameters(context.Background(),
+		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
+		QueryParameters{
+			"location": "sun-valley-1",
+		})
+
+	for iterator.Next() {
+		// process the result
+	}
+
+	// query with custom header
+	iterator, err = client.QueryWithParameters(context.Background(),
+		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
+		QueryParameters{
+			"location": "sun-valley-1",
+		},
+		WithHeader("X-trace-ID", "#0122"))
+
+	for iterator.Next() {
+		// process the result
+	}
+}

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -23,6 +23,8 @@
 package influxdb3
 
 import (
+	"net/http"
+
 	"github.com/influxdata/line-protocol/v2/lineprotocol"
 )
 
@@ -33,6 +35,9 @@ type QueryOptions struct {
 
 	// Query type.
 	QueryType QueryType
+
+	// Headers to be included in requests. Use to add or override headers in `ClientConfig`.
+	Headers http.Header
 }
 
 // WriteOptions holds options for write
@@ -110,6 +115,7 @@ type Option func(o *options)
 // Available options:
 //   - WithDatabase
 //   - WithQueryType
+//   - WithHeader
 type QueryOption = Option
 
 // WriteOption is a functional option type that can be passed to Client.Write methods.
@@ -132,6 +138,16 @@ func WithDatabase(database string) Option {
 func WithQueryType(queryType QueryType) Option {
 	return func(o *options) {
 		o.QueryType = queryType
+	}
+}
+
+// WithHeader is used to add or override default header in Client.Query method.
+func WithHeader(key, value string) Option {
+	return func(o *options) {
+		if o.Headers == nil {
+			o.Headers = make(http.Header, 0)
+		}
+		o.Headers[key] = []string{value}
 	}
 }
 

--- a/influxdb3/options_test.go
+++ b/influxdb3/options_test.go
@@ -1,6 +1,7 @@
 package influxdb3
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -38,6 +39,25 @@ func TestQueryOptions(t *testing.T) {
 			want: &QueryOptions{
 				Database:  "db-x",
 				QueryType: InfluxQL,
+			},
+		},
+		{
+			name: "add header",
+			opts: va(WithHeader("header-a", "value-a")),
+			want: &QueryOptions{
+				Headers: http.Header{
+					"header-a": {"value-a"},
+				},
+			},
+		},
+		{
+			name: "add headers",
+			opts: va(WithHeader("header-a", "value-a"), WithHeader("header-b", "value-b")),
+			want: &QueryOptions{
+				Headers: http.Header{
+					"header-a": {"value-a"},
+					"header-b": {"value-b"},
+				},
 			},
 		},
 	}

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -132,8 +132,27 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 	var queryType QueryType
 	queryType = options.QueryType
 
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+c.config.Token)
-	ctx = metadata.AppendToOutgoingContext(ctx, "database", database)
+	// add config headers
+	for k, v := range c.config.Headers {
+		if !c.isSystemHeader(k) {
+			for _, value := range v {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, value)
+			}
+		}
+	}
+
+	// add call options headers
+	for k, v := range options.Headers {
+		if !c.isSystemHeader(k) {
+			for _, value := range v {
+				ctx = metadata.AppendToOutgoingContext(ctx, k, value)
+			}
+		}
+	}
+
+	// add system headers
+	ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", "Bearer "+c.config.Token)
+	ctx = metadata.AppendToOutgoingContext(ctx, "Database", database)
 
 	ticketData := map[string]interface{}{
 		"database":   database,

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -152,7 +152,6 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 
 	// add system headers
 	ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", "Bearer "+c.config.Token)
-	ctx = metadata.AppendToOutgoingContext(ctx, "Database", database)
 
 	ticketData := map[string]interface{}{
 		"database":   database,

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -62,13 +62,13 @@ func (c *Client) initializeQueryClient() error {
 	if err != nil {
 		return fmt.Errorf("flight: %s", err)
 	}
-	c.queryClient = &client
+	c.queryClient = client
 
 	return nil
 }
 
 func (c *Client) setQueryClient(flightClient flight.Client) {
-	c.queryClient = &flightClient
+	c.queryClient = flightClient
 }
 
 // QueryParameters is a type for query parameters.
@@ -166,7 +166,7 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 	}
 
 	ticket := &flight.Ticket{Ticket: ticketJSON}
-	stream, err := (*c.queryClient).DoGet(ctx, ticket)
+	stream, err := c.queryClient.DoGet(ctx, ticket)
 	if err != nil {
 		return nil, fmt.Errorf("flight do get: %s", err)
 	}

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -97,9 +97,9 @@ func TestQueryWithCustomHeader(t *testing.T) {
 	assert.NotNil(t, middleware.outgoingMD, "outgoing MD is not nil")
 	assert.Contains(t, middleware.outgoingMD, "authorization", "auth header present")
 	assert.Contains(t, middleware.outgoingMD, "my-config-header", "custom config header present")
-	assert.Equal(t, middleware.outgoingMD["my-config-header"], []string{"hdr-config-1"}, "custom config header value")
+	assert.Equal(t, []string{"hdr-config-1"}, middleware.outgoingMD["my-config-header"], "custom config header value")
 	assert.Contains(t, middleware.outgoingMD, "my-call-header", "custom call header present")
-	assert.Equal(t, middleware.outgoingMD["my-call-header"], []string{"hdr-call-1"}, "custom call header value")
+	assert.Equal(t, []string{"hdr-call-1"}, middleware.outgoingMD["my-call-header"],"custom call header value")
 }
 
 // fake Flight server implementation

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -94,8 +94,7 @@ func TestQueryWithCustomHeader(t *testing.T) {
 
 	c.setQueryClient(fc)
 
-	iterator, err := c.Query(context.Background(), "SELECT * FROM nothing", WithHeader("my-call-header", "hdr-call-1"))
-	iterator.Raw().Release()
+	_, err = c.Query(context.Background(), "SELECT * FROM nothing", WithHeader("my-call-header", "hdr-call-1"))
 	require.NoError(t, err, "DoGet success")
 	assert.True(t, middleware.outgoingMDOk, "context contains outgoing MD")
 	assert.NotNil(t, middleware.outgoingMD, "outgoing MD is not nil")

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -24,6 +24,7 @@ package influxdb3
 
 import (
 	"context"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,4 +54,60 @@ func TestQueryWithOptionsNotSet(t *testing.T) {
 	assert.Nil(t, iterator)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "options not set")
+}
+
+func ExampleClient_Query() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// query
+	iterator, err := client.Query(context.Background(),
+		"SELECT count(*) FROM weather WHERE time >= now() - interval '5 minutes'")
+
+	for iterator.Next() {
+		// process the result
+	}
+
+	// query with custom header
+	iterator, err = client.Query(context.Background(),
+		"SELECT count(*) FROM stat WHERE time >= now() - interval '5 minutes'",
+		WithHeader("X-trace-ID", "#0122"))
+
+	for iterator.Next() {
+		// process the result
+	}
+}
+
+func ExampleClient_QueryWithParameters() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	// query
+	iterator, err := client.QueryWithParameters(context.Background(),
+		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
+		QueryParameters{
+			"location": "sun-valley-1",
+		})
+
+	for iterator.Next() {
+		// process the result
+	}
+
+	// query with custom header
+	iterator, err = client.QueryWithParameters(context.Background(),
+		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
+		QueryParameters{
+			"location": "sun-valley-1",
+		},
+		WithHeader("X-trace-ID", "#0122"))
+
+	for iterator.Next() {
+		// process the result
+	}
 }

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -24,7 +24,6 @@ package influxdb3
 
 import (
 	"context"
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,60 +53,4 @@ func TestQueryWithOptionsNotSet(t *testing.T) {
 	assert.Nil(t, iterator)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "options not set")
-}
-
-func ExampleClient_Query() {
-	client, err := NewFromEnv()
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Close()
-
-	// query
-	iterator, err := client.Query(context.Background(),
-		"SELECT count(*) FROM weather WHERE time >= now() - interval '5 minutes'")
-
-	for iterator.Next() {
-		// process the result
-	}
-
-	// query with custom header
-	iterator, err = client.Query(context.Background(),
-		"SELECT count(*) FROM stat WHERE time >= now() - interval '5 minutes'",
-		WithHeader("X-trace-ID", "#0122"))
-
-	for iterator.Next() {
-		// process the result
-	}
-}
-
-func ExampleClient_QueryWithParameters() {
-	client, err := NewFromEnv()
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Close()
-
-	// query
-	iterator, err := client.QueryWithParameters(context.Background(),
-		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
-		QueryParameters{
-			"location": "sun-valley-1",
-		})
-
-	for iterator.Next() {
-		// process the result
-	}
-
-	// query with custom header
-	iterator, err = client.QueryWithParameters(context.Background(),
-		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
-		QueryParameters{
-			"location": "sun-valley-1",
-		},
-		WithHeader("X-trace-ID", "#0122"))
-
-	for iterator.Next() {
-		// process the result
-	}
 }

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -24,10 +24,16 @@ package influxdb3
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	"github.com/apache/arrow/go/v15/arrow"
+	"github.com/apache/arrow/go/v15/arrow/flight"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestQueryDatabaseNotSet(t *testing.T) {
@@ -53,4 +59,78 @@ func TestQueryWithOptionsNotSet(t *testing.T) {
 	assert.Nil(t, iterator)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "options not set")
+}
+
+func TestQueryWithCustomHeader(t *testing.T) {
+	s := flight.NewServerWithMiddleware(nil)
+	err := s.Init("localhost:18080")
+	require.NoError(t, err)
+	f := &flightServer{}
+	s.RegisterFlightService(f)
+
+	go s.Serve()
+	defer s.Shutdown()
+
+	middleware := &callHeadersMiddleware{}
+	fc, err := flight.NewClientWithMiddleware(s.Addr().String(), nil, []flight.ClientMiddleware{
+		flight.CreateClientMiddleware(middleware),
+	}, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer fc.Close()
+
+	c, err := New(ClientConfig{
+		Host: "http://localhost:80",
+		Token: "my-token",
+		Database: "my-database",
+		Headers: http.Header{
+			"my-config-header": {"hdr-config-1"},
+		},
+	})
+	require.NoError(t, err)
+	defer c.Close()
+
+	c.setQueryClient(fc)
+
+	_, err = c.Query(context.Background(), "SELECT * FROM nothing", WithHeader("my-call-header", "hdr-call-1"))
+	_ = err // ignore it is EOF
+	assert.True(t, middleware.outgoingMDOk, "context contains outgoing MD")
+	assert.NotNil(t, middleware.outgoingMD, "outgoing MD is not nil")
+	assert.Contains(t, middleware.outgoingMD, "authorization", "auth header present")
+	assert.Contains(t, middleware.outgoingMD, "my-config-header", "custom config header present")
+	assert.Equal(t, middleware.outgoingMD["my-config-header"], []string{"hdr-config-1"}, "custom config header value")
+	assert.Contains(t, middleware.outgoingMD, "my-call-header", "custom call header present")
+	assert.Equal(t, middleware.outgoingMD["my-call-header"], []string{"hdr-call-1"}, "custom call header value")
+}
+
+// fake Flight server implementation
+
+type flightServer struct {
+	flight.BaseFlightServer
+}
+
+func (f *flightServer) DoGet(tkt *flight.Ticket, fs flight.FlightService_DoGetServer) error {
+	records := [0]arrow.Record{} // empty array will cause EOF but we do not need the result anyway, for now
+
+	w := flight.NewRecordWriter(fs)
+	for _, r := range records {
+		w.Write(r)
+	}
+
+	return nil
+}
+
+type callHeadersMiddleware struct {
+	outgoingMDOk bool
+	outgoingMD   metadata.MD
+}
+
+func (c *callHeadersMiddleware) StartCall(ctx context.Context) context.Context {
+	return ctx
+}
+
+func (c *callHeadersMiddleware) CallCompleted(ctx context.Context, err error) {
+}
+
+func (c *callHeadersMiddleware) HeadersReceived(ctx context.Context, md metadata.MD) {
+	c.outgoingMD, c.outgoingMDOk = metadata.FromOutgoingContext(ctx)
 }


### PR DESCRIPTION
## Proposed Changes

* Adds custom headers (from either `ClientConfig` and/or provided to query via `WithHeader` options)  to a gRPC query request.
* Query call examples are now in "godoc" style - compilable (but not executed during `go test`) code in `example_query_test.go`, from which documentation examples are generated and linked with functions and types on `pkg.go.dev` portal, see #78 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
