### PR TITLE
chore: do not run e2e on PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,12 @@ jobs:
             go install golang.org/x/lint/golint@latest && golint ./...
       - run:
           name: Run tests
-          command: GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out --tags e2e ./...
+          command: |
+            if [ "${CIRCLE_BRANCH}" == pull/* ];
+              GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out ./...
+            else
+              GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out --tags e2e ./...
+            fi
       - run:
           name: Coverage Report
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            if [ "${CIRCLE_BRANCH}" == pull/* ]; then
+            if [[ "$CIRCLE_BRANCH" == pull/* ]]; then
               GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out ./...
             else
               GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out --tags e2e ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            if [ "${CIRCLE_BRANCH}" == pull/* ];
+            if [ "${CIRCLE_BRANCH}" == pull/* ]; then
               GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out ./...
             else
               GOEXPERIMENT=nocoverageredesign go test -v -cover -coverprofile=coverage.out --tags e2e ./...

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
  The MIT License
 


### PR DESCRIPTION
## Proposed Changes

Changes CircleCI job not to run e2e tests on PRs from forks. `CIRCLE_BRANCH` env var is set to `pull/NUMBER` when run for fork PR: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/

## Checklist

- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
