### PR TITLE
fix: use godoc examples instead of code comments

### DIFF
--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -120,8 +120,6 @@ func New(config ClientConfig) (*Client, error) {
 //   - database - database (bucket) name
 //   - precision - timestamp precision when writing data
 //   - gzipThreshold - payload size threshold for gzipping data
-//
-// Example: https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database
 func NewFromConnectionString(connectionString string) (*Client, error) {
 	cfg := ClientConfig{}
 	err := cfg.parse(connectionString)

--- a/influxdb3/example_test.go
+++ b/influxdb3/example_test.go
@@ -1,0 +1,54 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import "log"
+
+func ExampleNew() {
+	client, err := New(ClientConfig{
+		Host:     "https://us-east-1-1.aws.cloud2.influxdata.com",
+		Token:    "my-token",
+		Database: "my-database",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+}
+
+func ExampleNewFromConnectionString() {
+	client, err := NewFromConnectionString("https://us-east-1-1.aws.cloud2.influxdata.com/?token=my-token&database=my-database")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+}
+
+func ExampleNewFromEnv() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+}
+

--- a/influxdb3/example_write_test.go
+++ b/influxdb3/example_write_test.go
@@ -1,0 +1,126 @@
+/*
+ The MIT License
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+*/
+
+package influxdb3
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/influxdata/line-protocol/v2/lineprotocol"
+)
+
+func ExampleClient_Write() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal()
+	}
+	defer client.Close()
+
+	l0 := "cpu,host=localhost usage_user=16.75"
+	l1 := "cpu,host=gw usage_user=2.90"
+	data := []byte(strings.Join([]string{l0, l1}, "\n"))
+
+	// write line protocol
+	err = client.Write(context.Background(), data)
+	if err != nil {
+		log.Fatal()
+	}
+
+	// write line protocol with options
+	err = client.Write(context.Background(), data, WithDatabase("another-database"), WithGzipThreshold(64))
+	if err != nil {
+		log.Fatal()
+	}
+}
+
+func ExampleClient_WritePoints() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal()
+	}
+	defer client.Close()
+
+	p0 := NewPointWithMeasurement("cpu")
+	p0.SetTag("host", "localhost")
+	p0.SetField("usage_user", 16.75)
+	p0.SetTimestamp(time.Now())
+	points := []*Point{p0}
+
+	// write points
+	err = client.WritePoints(context.Background(), points)
+	if err != nil {
+		log.Fatal()
+	}
+
+	// write points with options
+	err = client.WritePoints(context.Background(), points, WithPrecision(lineprotocol.Second))
+	if err != nil {
+		log.Fatal()
+	}
+}
+
+func ExampleClient_WriteData() {
+	type AirSensor struct {
+		Measurement string    `lp:"measurement"`
+		Sensor      string    `lp:"tag,sensor"`
+		ID          string    `lp:"tag,device_id"`
+		Temp        float64   `lp:"field,temperature"`
+		Hum         int       `lp:"field,humidity"`
+		Time        time.Time `lp:"timestamp"`
+		Description string    `lp:"-"`
+	}
+
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal()
+	}
+	defer client.Close()
+
+	p0 := AirSensor{
+		"air",
+		"SHT31",
+		"10",
+		23.5,
+		55,
+		time.Now(),
+		"Room temp",
+	}
+	points := []any{&p0}
+
+	// write points
+	err = client.WriteData(context.Background(), points)
+	if err != nil {
+		log.Fatal()
+	}
+
+	// write points with options
+	err = client.WriteData(context.Background(), points, WithDefaultTags(map[string]string{
+		"version":"0.1",
+	}))
+	if err != nil {
+		log.Fatal()
+	}
+}
+

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -45,47 +45,6 @@ type WriteOptions struct {
 	Precision lineprotocol.Precision
 
 	// Tags added to each point during writing. If a point already has a tag with the same key, it is left unchanged.
-	//
-	// Example using WritePointsWithOptions:
-	//  c, _ := New(ClientConfig{
-	//  	Host:         "host",
-	//  	Token:        "my-token",
-	//  	Organization: "my-org",
-	//  	Database:     "my-database",
-	//  })
-	//
-	// Example:
-	//  options := WriteOptions{
-	//  	DefaultTags: map[string]string{
-	//  		"rack": "main",
-	//  	},
-	//  	Precision: lineprotocol.Millisecond,
-	//  }
-	//
-	//  p := NewPointWithMeasurement("measurement")
-	//  p.SetField("number", 10)
-	//
-	//  // Writes with rack=main tag
-	//  c.WritePointsWithOptions(context.Background(), &options, p)
-	//
-	// Example using ClientConfig:
-	//  c, _ := New(ClientConfig{
-	//  	Host:         "host",
-	//  	Token:        "my-token",
-	//  	Organization: "my-org",
-	//  	Database:     "my-database",
-	//  	WriteOptions: &WriteOptions{
-	//  		DefaultTags: map[string]string{
-	//  			"rack": "main",
-	//  		},
-	//  	},
-	//  })
-	//
-	//  p := NewPointWithMeasurement("measurement")
-	//  p.SetField("number", 10)
-	//
-	//  // Writes with rack=main tag
-	//  c.WritePoints(context.Background(), p)
 	DefaultTags map[string]string
 
 	// Write body larger than the threshold is gzipped. 0 for no compression.

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -185,18 +185,6 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 //
 // A field with a timestamp must be of type time.Time.
 //
-// Example usage:
-//
-//	type TemperatureSensor struct {
-//	    Measurement  string    `lp:"measurement"`
-//	    Sensor       string    `lp:"tag,sensor"`
-//	    ID           string    `lp:"tag,device_id"`
-//	    Temp         float64   `lp:"field,temperature"`
-//	    Hum          int       `lp:"field,humidity"`
-//	    Time         time.Time `lp:"timestamp"`
-//	    Description  string    `lp:"-"`
-//	}
-//
 // Parameters:
 //   - ctx: The context.Context to use for the request.
 //   - points: The custom points to encode and write.
@@ -215,18 +203,6 @@ func (c *Client) WriteData(ctx context.Context, points []interface{}, options ..
 // The points are written synchronously.
 //
 // A field with a timestamp must be of type time.Time.
-//
-// Example usage:
-//
-//	type TemperatureSensor struct {
-//	    Measurement  string    `lp:"measurement"`
-//	    Sensor       string    `lp:"tag,sensor"`
-//	    ID           string    `lp:"tag,device_id"`
-//	    Temp         float64   `lp:"field,temperature"`
-//	    Hum          int       `lp:"field,humidity"`
-//	    Time         time.Time `lp:"timestamp"`
-//	    Description  string    `lp:"-"`
-//	}
 //
 // Parameters:
 //   - ctx: The context.Context to use for the request.


### PR DESCRIPTION
## Proposed Changes

Examples (`Write` and `New` calls, `Query` is done in #76) are now in "godoc" style - compilable (but not executed during `go test`) code in `example_query_test.go`, from which documentation examples are generated and linked with functions and types on `pkg.go.dev` portal, eg.:

![image](https://github.com/InfluxCommunity/influxdb3-go/assets/42931850/9e4e6a39-945b-4d8d-a365-7c079149eaf7)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
