### PR TITLE
feat: user-agent header in gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.8.0 [unreleased]
 
+### Features
+
+1. [#85](https://github.com/InfluxCommunity/influxdb3-go/pull/85): Add standard `user-agent` header to gRPC requests.
+
 ## 0.7.0 [2024-04-16]
 
 ### Features

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -133,8 +133,7 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 		return nil, errors.New("database not specified")
 	}
 
-	var queryType QueryType
-	queryType = options.QueryType
+	var queryType QueryType = options.QueryType
 
 	md := make(metadata.MD, 0)
 	for k, v := range c.config.Headers {
@@ -148,6 +147,7 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 		}
 	}
 	md.Set("authorization", "Bearer "+c.config.Token)
+	md.Set("User-Agent", userAgent)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	ticketData := map[string]interface{}{

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -144,11 +144,9 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 		return fmt.Errorf("database not specified")
 	}
 
-	var precision lineprotocol.Precision
-	precision = options.Precision
+	var precision = options.Precision
 
-	var gzipThreshold int
-	gzipThreshold = options.GzipThreshold
+	var gzipThreshold = options.GzipThreshold
 
 	var body io.Reader
 	var err error


### PR DESCRIPTION
## Proposed Changes

* Sets `user-agent` header in metadata for query calls by default
* Adds test for default headers in query calls
* Cleans up a couple of lines in writer that linter complained about locally

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
