### PR TITLE
feat: add a token prefix for config

### DIFF
--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -88,7 +88,10 @@ func New(config ClientConfig) (*Client, error) {
 	c.apiURL.Path = path.Join(c.apiURL.Path, "api/v2") + "/"
 
 	// Prepare auth header value
-	c.authorization = "Token " + c.config.Token
+	if c.config.TokenPrefix == "" {
+		c.config.TokenPrefix = "Token"
+	}
+	c.authorization = fmt.Sprintf("%s %s", c.config.TokenPrefix, c.config.Token)
 
 	// Prepare HTTP client
 	if c.config.HTTPClient == nil {

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -54,6 +54,9 @@ type ClientConfig struct {
 	// This can be obtained through the GUI web browser interface.
 	Token string
 
+	// TokenPrefix for example, a Token, Bearer
+	TokenPrefix string
+
 	// Organization is name or ID of organization where data (databases, users, tasks, etc.) belongs to
 	// Optional for InfluxDB Cloud
 	Organization string


### PR DESCRIPTION
When I use client to write data, influxv3 displays a message indicating
```
 panic: {"error":"Authorization header was malformed and should be in the form 'Authorization: Bearer <token>'"}
```
, so I submit this pr

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
