### PR TITLE
feat: Edge authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#87](https://github.com/InfluxCommunity/influxdb3-go/pull/87): Add Cloud Dedicated database creation support
+1. [#91](https://github.com/InfluxCommunity/influxdb3-go/pull/91): Add Edge (OSS) authentication support.
 
 ## 0.8.0 [2024-06-24]
 

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -87,11 +87,12 @@ func New(config ClientConfig) (*Client, error) {
 	}
 	c.apiURL.Path = path.Join(c.apiURL.Path, "api/v2") + "/"
 
-	// Prepare auth header value
-	if c.config.TokenPrefix == "" {
-		c.config.TokenPrefix = "Token"
+	// Prepare authorization header value
+	authScheme := c.config.AuthScheme
+	if authScheme == "" {
+		authScheme = "Token"
 	}
-	c.authorization = fmt.Sprintf("%s %s", c.config.TokenPrefix, c.config.Token)
+	c.authorization = fmt.Sprintf("%s %s", authScheme, c.config.Token)
 
 	// Prepare HTTP client
 	if c.config.HTTPClient == nil {

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -88,7 +88,10 @@ func New(config ClientConfig) (*Client, error) {
 	c.apiURL.Path = path.Join(c.apiURL.Path, "api/v2") + "/"
 
 	// Prepare auth header value
-	c.authorization = "Token " + c.config.Token
+	if c.config.TokenPrefix == "" {
+		c.config.TokenPrefix = "Token"
+	}
+	c.authorization = fmt.Sprintf("%s %s", c.config.TokenPrefix, c.config.Token)
 
 	// Prepare HTTP client
 	if c.config.HTTPClient == nil {

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -74,6 +74,20 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "my-database", c.config.Database)
 	assert.Equal(t, "my-org", c.config.Organization)
 	assert.EqualValues(t, DefaultWriteOptions, *c.config.WriteOptions)
+
+	c, err = New(ClientConfig{
+		Host:         "http://localhost:8086",
+		Token:        "my-token",
+		AuthScheme:   "my-auth-scheme",
+		Organization: "my-org",
+		Database:     "my-database",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "my-auth-scheme my-token", c.authorization)
+	assert.Equal(t, "my-database", c.config.Database)
+	assert.Equal(t, "my-org", c.config.Organization)
+	assert.EqualValues(t, DefaultWriteOptions, *c.config.WriteOptions)
 }
 
 func TestURLs(t *testing.T) {
@@ -141,6 +155,18 @@ func TestNewFromConnectionString(t *testing.T) {
 			},
 		},
 		{
+			name: "with auth scheme",
+			cs:   "https://host:8086?token=abc&authScheme=Custom&org=my-org&database=my-db",
+			cfg: &ClientConfig{
+				Host:         "https://host:8086",
+				Token:        "abc",
+				AuthScheme:   "Custom",
+				Organization: "my-org",
+				Database:     "my-db",
+				WriteOptions: &DefaultWriteOptions,
+			},
+		},
+		{
 			name: "with write options",
 			cs:   "https://host:8086?token=abc&org=my-org&database=my-db&precision=ms",
 			cfg: &ClientConfig{
@@ -171,6 +197,7 @@ func TestNewFromConnectionString(t *testing.T) {
 				assert.NotNil(t, c)
 				assert.Equal(t, tc.cfg.Host, c.config.Host)
 				assert.Equal(t, tc.cfg.Token, c.config.Token)
+				assert.Equal(t, tc.cfg.AuthScheme, c.config.AuthScheme)
 				assert.Equal(t, tc.cfg.Organization, c.config.Organization)
 				assert.Equal(t, tc.cfg.Database, c.config.Database)
 				assert.Equal(t, tc.cfg.WriteOptions, c.config.WriteOptions)
@@ -211,7 +238,7 @@ func TestNewFromEnv(t *testing.T) {
 			},
 		},
 		{
-			name: "simple",
+			name: "basic",
 			vars: map[string]string{
 				"INFLUX_HOST":     "http://host:8086",
 				"INFLUX_TOKEN":    "abc",
@@ -221,6 +248,24 @@ func TestNewFromEnv(t *testing.T) {
 			cfg: &ClientConfig{
 				Host:         "http://host:8086",
 				Token:        "abc",
+				Organization: "my-org",
+				Database:     "my-db",
+				WriteOptions: &DefaultWriteOptions,
+			},
+		},
+		{
+			name: "with auth scheme",
+			vars: map[string]string{
+				"INFLUX_HOST":        "http://host:8086",
+				"INFLUX_TOKEN":       "abc",
+				"INFLUX_AUTH_SCHEME": "Custom",
+				"INFLUX_ORG":         "my-org",
+				"INFLUX_DATABASE":    "my-db",
+			},
+			cfg: &ClientConfig{
+				Host:         "http://host:8086",
+				Token:        "abc",
+				AuthScheme:   "Custom",
 				Organization: "my-org",
 				Database:     "my-db",
 				WriteOptions: &DefaultWriteOptions,
@@ -269,6 +314,7 @@ func TestNewFromEnv(t *testing.T) {
 	clearEnv := func() {
 		os.Unsetenv(envInfluxHost)
 		os.Unsetenv(envInfluxToken)
+		os.Unsetenv(envInfluxAuthScheme)
 		os.Unsetenv(envInfluxOrg)
 		os.Unsetenv(envInfluxDatabase)
 		os.Unsetenv(envInfluxPrecision)
@@ -292,6 +338,7 @@ func TestNewFromEnv(t *testing.T) {
 				assert.NotNil(t, c)
 				assert.Equal(t, tc.cfg.Host, c.config.Host)
 				assert.Equal(t, tc.cfg.Token, c.config.Token)
+				assert.Equal(t, tc.cfg.AuthScheme, c.config.AuthScheme)
 				assert.Equal(t, tc.cfg.Organization, c.config.Organization)
 				assert.Equal(t, tc.cfg.Database, c.config.Database)
 				assert.Equal(t, tc.cfg.WriteOptions, c.config.WriteOptions)
@@ -328,64 +375,19 @@ func TestMakeAPICall(t *testing.T) {
 		endpointURL: turl,
 		queryParams: nil,
 		httpMethod:  "GET",
-		headers:     http.Header{"Authorization": {"Bearer managment-api-token"}},
+		headers:     http.Header{"Authorization": {"Bearer management-api-token"}},
 		body:        nil,
 	})
-	assert.Equal(t, "Bearer managment-api-token", res.Request.Header.Get("Authorization"))
+	assert.Equal(t, "Bearer management-api-token", res.Request.Header.Get("Authorization"))
 	assert.Nil(t, err)
-}
 
-func TestMakeAPICallWithTokenPrefix(t *testing.T) {
-	html := `<html><body><h1>Response</h1></body></html>`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
-			auth := r.Header.Get("Authorization")
-			assert.Equal(t, "Bearer my-token", auth)
-		}
-		w.Header().Add("Content-Type", "text/html")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(html))
-	}))
-	defer ts.Close()
-	client, err := New(ClientConfig{Host: ts.URL, Token: "my-token", TokenPrefix: "Bearer"})
+	client, err = New(ClientConfig{Host: ts.URL, Token: "my-token", AuthScheme: "Bearer"})
 	require.NoError(t, err)
-	turl, err := url.Parse(ts.URL)
-	require.NoError(t, err)
-	res, err := client.makeAPICall(context.Background(), httpParams{
+	res, err = client.makeAPICall(context.Background(), httpParams{
 		endpointURL: turl,
-		queryParams: nil,
 		httpMethod:  "GET",
-		headers:     nil,
-		body:        nil,
 	})
-	assert.NotNil(t, res)
-	assert.Nil(t, err)
-}
-
-func TestMakeAPICallWithNoTokenPrefix(t *testing.T) {
-	html := `<html><body><h1>Response</h1></body></html>`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
-			auth := r.Header.Get("Authorization")
-			assert.Equal(t, "Token my-token", auth)
-		}
-		w.Header().Add("Content-Type", "text/html")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(html))
-	}))
-	defer ts.Close()
-	client, err := New(ClientConfig{Host: ts.URL, Token: "my-token"})
-	require.NoError(t, err)
-	turl, err := url.Parse(ts.URL)
-	require.NoError(t, err)
-	res, err := client.makeAPICall(context.Background(), httpParams{
-		endpointURL: turl,
-		queryParams: nil,
-		httpMethod:  "GET",
-		headers:     nil,
-		body:        nil,
-	})
-	assert.NotNil(t, res)
+	assert.Equal(t, "Bearer my-token", res.Request.Header.Get("Authorization"))
 	assert.Nil(t, err)
 }
 

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -335,6 +335,60 @@ func TestMakeAPICall(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestMakeAPICallWithTokenPrefix(t *testing.T) {
+	html := `<html><body><h1>Response</h1></body></html>`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			auth := r.Header.Get("Authorization")
+			assert.Equal(t, "Bearer my-token", auth)
+		}
+		w.Header().Add("Content-Type", "text/html")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(html))
+	}))
+	defer ts.Close()
+	client, err := New(ClientConfig{Host: ts.URL, Token: "my-token", TokenPrefix: "Bearer"})
+	require.NoError(t, err)
+	turl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	res, err := client.makeAPICall(context.Background(), httpParams{
+		endpointURL: turl,
+		queryParams: nil,
+		httpMethod:  "GET",
+		headers:     nil,
+		body:        nil,
+	})
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+}
+
+func TestMakeAPICallWithNoTokenPrefix(t *testing.T) {
+	html := `<html><body><h1>Response</h1></body></html>`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			auth := r.Header.Get("Authorization")
+			assert.Equal(t, "Token my-token", auth)
+		}
+		w.Header().Add("Content-Type", "text/html")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(html))
+	}))
+	defer ts.Close()
+	client, err := New(ClientConfig{Host: ts.URL, Token: "my-token"})
+	require.NoError(t, err)
+	turl, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	res, err := client.makeAPICall(context.Background(), httpParams{
+		endpointURL: turl,
+		queryParams: nil,
+		httpMethod:  "GET",
+		headers:     nil,
+		body:        nil,
+	})
+	assert.NotNil(t, res)
+	assert.Nil(t, err)
+}
+
 func TestResolveErrorMessage(t *testing.T) {
 	errMsg := "compilation failed: error at @1:170-1:171: invalid expression @1:167-1:168: |"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -54,6 +54,9 @@ type ClientConfig struct {
 	// This can be obtained through the GUI web browser interface.
 	Token string
 
+	// TokenPrefix for example, a Token, Bearer
+	TokenPrefix string
+
 	// Organization is name or ID of organization where data (databases, users, tasks, etc.) belongs to
 	// Optional for InfluxDB Cloud
 	Organization string


### PR DESCRIPTION
Closes #88

## Proposed Changes

_Briefly describe your proposed changes:_

Refactored #88, based on my comments there:
*  does not modify client-provided `config` instance (by setting fallback value to unset property)
* renamed property `TokenPrefix` -> `AuthScheme` per terminology used eg. in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
* `AuthScheme` also supported in Client init from connection string and/or environment variables

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
