### PR TITLE
fix: unclosed body causing resource leak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Lint go code
           command: |
-            golangci-lint run -v
+            golangci-lint run -v --tests=false
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - run:
           name: Lint go code
           command: |
-            golangci-lint run -v --tests=false
+            golangci-lint run -v
 
 workflows:
   version: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - bodyclose
 
 output:
   # The formats used to render issues.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - ineffassign
     - staticcheck
     - unused
-    - bodyclose
 
 output:
   # The formats used to render issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.10.0 [unreleased]
 
+### Bug Fixes
+
+1. [#94](https://github.com/InfluxCommunity/influxdb3-go/pull/94): Resource leak from unclosed `Response`
+
 ## 0.9.0 [2024-08-12]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 1. [#95](https://github.com/InfluxCommunity/influxdb3-go/pull/95): Add `golangci-lint` to CI
 
-
 ## 0.9.0 [2024-08-12]
 
 ### Features

--- a/influxdb3/management_cloud_decicated.go
+++ b/influxdb3/management_cloud_decicated.go
@@ -143,6 +143,9 @@ func (d *CloudDedicatedClient) createDatabase(ctx context.Context, path string, 
 		body:        bytes.NewReader(body),
 	}
 
-	_, err = d.client.makeAPICall(ctx, param)
-	return err
+	resp, err := d.client.makeAPICall(ctx, param)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
 }

--- a/influxdb3/management_serverless.go
+++ b/influxdb3/management_serverless.go
@@ -95,6 +95,9 @@ func (c *ServerlessClient) createBucket(ctx context.Context, path string, bucket
 		body:        bytes.NewReader(body),
 	}
 
-	_, err = c.client.makeAPICall(ctx, param)
-	return err
+	resp, err := c.client.makeAPICall(ctx, param)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
 }

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -165,14 +165,17 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 		}
 		headers["Content-Encoding"] = []string{"gzip"}
 	}
-	_, err = c.makeAPICall(ctx, httpParams{
+	resp, err := c.makeAPICall(ctx, httpParams{
 		endpointURL: u,
 		httpMethod:  "POST",
 		headers:     headers,
 		queryParams: u.Query(),
 		body:        body,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
 }
 
 // WriteData encodes fields of custom points into line protocol


### PR DESCRIPTION
## Proposed Changes

When the returned `Response`'s body is `nil`, the caller of the function is expected to `Close` the body. If this is not done, it can lead to a resource leak.

[Ref](https://pkg.go.dev/net/http#Client.Do)

>If the returned error is nil, the Response will contain a non-nil Body which the user is expected to close.

This is also caught by a `golangci-lint` check of `bodyclose`, e.g. running from `main`:

```bash
git branch --show-current
main

golangci-lint run --enable-only bodyclose
influxdb3/management_cloud_decicated.go:146:31: response body must be closed (bodyclose)
        _, err = d.client.makeAPICall(ctx, param)
                                     ^
influxdb3/management_serverless.go:98:31: response body must be closed (bodyclose)
        _, err = c.client.makeAPICall(ctx, param)
                                     ^
influxdb3/write.go:168:24: response body must be closed (bodyclose)
        _, err = c.makeAPICall(ctx, httpParams{
                              ^
```


Other references:

- [What if I don't close the response body?](https://stackoverflow.com/questions/33238518/what-could-happen-if-i-dont-close-response-body)
- [Go Response Body MUST be closed, even if you don't read it](https://manishrjain.com/must-close-golang-http-response)

This is mainly believed to effect a Clustered customer, but I've also addressed the lint elsewhere too for Cloud Dedicated/Serverless[^1].

[^1]: This also shows up in various tests, but I've opted to leave this for now because they are ephemeral compared to client usage. If needs be I think someone can address these in a follow-up PR.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
