### PR TITLE
chore: add `golangci-lint` to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2.1
+
 jobs:
-  build:
-    working_directory: ~/repo
+  tests-go:
+    parameters:
+      go-image:
+        type: string
+        default: "cimg/go:1.22"
     docker:
-      - image: cimg/go:1.22
+      - image: << parameters.go-image >>
     steps:
       - checkout
       - restore_cache:
@@ -53,3 +57,20 @@ jobs:
             ./codecov
       - store_artifacts:
           path: /tmp/artifacts
+
+  lint:
+    docker:
+      - image: golangci/golangci-lint
+    steps:
+      - checkout
+      - run:
+          name: Lint go code
+          command: |
+            golangci-lint run -v
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - tests-go
+      - lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+output:
+  # The formats used to render issues.
+  # Default:
+  #   formats:
+  #     - format: colored-line-number
+  #       path: stdout
+  formats:
+    - format: tab
+      path: stdout
+
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
+
+  # Sort results by the order defined in `sort-order`.
+  # Default: false
+  sort-results: true
+
+  # Show statistics per linter.
+  # Default: false
+  show-stats: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.10.0 [unreleased]
 
+### CI
+
+1. [#95](https://github.com/InfluxCommunity/influxdb3-go/pull/95): Add `golangci-lint` to CI
+
 ## 0.9.0 [2024-08-12]
 
 ### Features

--- a/influxdb3/example_query_test.go
+++ b/influxdb3/example_query_test.go
@@ -35,7 +35,7 @@ func ExampleClient_Query() {
 	defer client.Close()
 
 	// query
-	iterator, err := client.Query(context.Background(),
+	iterator, _ := client.Query(context.Background(),
 		"SELECT count(*) FROM weather WHERE time >= now() - interval '5 minutes'")
 
 	for iterator.Next() {
@@ -43,7 +43,7 @@ func ExampleClient_Query() {
 	}
 
 	// query with custom header
-	iterator, err = client.Query(context.Background(),
+	iterator, _ = client.Query(context.Background(),
 		"SELECT count(*) FROM stat WHERE time >= now() - interval '5 minutes'",
 		WithHeader("X-trace-ID", "#0122"))
 
@@ -60,7 +60,7 @@ func ExampleClient_QueryWithParameters() {
 	defer client.Close()
 
 	// query
-	iterator, err := client.QueryWithParameters(context.Background(),
+	iterator, _ := client.QueryWithParameters(context.Background(),
 		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
 		QueryParameters{
 			"location": "sun-valley-1",
@@ -71,7 +71,7 @@ func ExampleClient_QueryWithParameters() {
 	}
 
 	// query with custom header
-	iterator, err = client.QueryWithParameters(context.Background(),
+	iterator, _ = client.QueryWithParameters(context.Background(),
 		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
 		QueryParameters{
 			"location": "sun-valley-1",

--- a/influxdb3/query_test.go
+++ b/influxdb3/query_test.go
@@ -143,7 +143,7 @@ func TestQueryWithDefaultHeaders(t *testing.T) {
 	defer c.Close()
 
 	c.setQueryClient(fc)
-	_, err = c.Query(context.Background(), "SELECT * FROM nothing")
+	_, _ = c.Query(context.Background(), "SELECT * FROM nothing")
 	assert.True(t, middleware.outgoingMDOk, "context contains outgoing MD")
 	assert.Equal(t, []string{userAgent}, middleware.outgoingMD["user-agent"], "default user agent header set")
 	assert.Equal(t, []string{"Bearer my-token"}, middleware.outgoingMD["authorization"], "authorization header set")


### PR DESCRIPTION
Related to #94 

## Proposed Changes

Add https://golangci-lint.run to our CI.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
