### PR TITLE
fix: e2e tests

### DIFF
--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -228,7 +229,7 @@ func TestQueryDatabaseDoesNotExist(t *testing.T) {
 		Database: "does not exist",
 	})
 
-	iterator, err := client.Query(context.Background(), "SHOW NAMESPACES")
+	iterator, err := client.Query(context.Background(), "SHOW TABLES")
 	assert.Nil(t, iterator)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "bucket \"does not exist\" not found")
@@ -245,7 +246,7 @@ func TestQuerySchema(t *testing.T) {
 		Database: database,
 	})
 
-	iterator, err := client.Query(context.Background(), "SHOW NAMESPACES")
+	iterator, err := client.Query(context.Background(), "SHOW TABLES")
 	require.NoError(t, err)
 	assert.NotNil(t, iterator.Raw())
 }
@@ -261,7 +262,7 @@ func TestQuerySchemaWithOptions(t *testing.T) {
 		Database: "does not exist",
 	})
 
-	iterator, err := client.Query(context.Background(), "SHOW NAMESPACES", influxdb3.WithDatabase(database))
+	iterator, err := client.Query(context.Background(), "SHOW TABLES", influxdb3.WithDatabase(database))
 	require.NoError(t, err)
 	assert.NotNil(t, iterator.Raw())
 }


### PR DESCRIPTION
## Proposed Changes

The "SHOW NAMESPACES" is not allowed to use. The tests was failing with:

```
--- FAIL: TestQuerySchemaWithOptions (0.47s)
    client_e2e_test.go:266: 
                Error Trace:    /Users/bednar/Developer/InfluxData/influxdb3-go/influxdb3/client_e2e_test.go:266
                Error:          Received unexpected error:
                                flight reader: rpc error: code = InvalidArgument desc = Error while planning query: Error during planning: 'namespaces' is not a variable which can be viewed with 'SHOW'
                Test:           TestQuerySchemaWithOptions

```

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/90a53eeb-b078-4b74-b7f0-0be59f01e9ff">

https://app.circleci.com/pipelines/github/InfluxCommunity/influxdb3-go/347/workflows/c1980310-4c9e-4757-83ca-f3833517be47/jobs/371

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
