### PR TITLE
fix: CloudDedicated database creation ignores the given name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#94](https://github.com/InfluxCommunity/influxdb3-go/pull/94): Resource leak from unclosed `Response`
+1. [#98](https://github.com/InfluxCommunity/influxdb3-go/pull/98): Cloud Dedicated database creation ignores the name given by an argument
 
 ### CI
 

--- a/influxdb3/management_cloud_decicated.go
+++ b/influxdb3/management_cloud_decicated.go
@@ -87,7 +87,8 @@ func NewCloudDedicatedClient(client *Client) *CloudDedicatedClient {
 	return &CloudDedicatedClient{client: client}
 }
 
-// CreateDatabase creates a new database
+// CreateDatabase creates a new database. If Database.ClusterDatabaseName is
+// not provided, it defaults to the database name configured in Client.
 func (d *CloudDedicatedClient) CreateDatabase(ctx context.Context, config *CloudDedicatedClientConfig, db *Database) error {
 	if db == nil {
 		return errors.New("database must not nil")

--- a/influxdb3/management_cloud_decicated.go
+++ b/influxdb3/management_cloud_decicated.go
@@ -93,10 +93,12 @@ func (d *CloudDedicatedClient) CreateDatabase(ctx context.Context, config *Cloud
 		return errors.New("database must not nil")
 	}
 
-	if d.client.config.Database == "" {
-		return errors.New("database name must not be empty")
+	if db.ClusterDatabaseName == "" {
+		if d.client.config.Database == "" {
+			return errors.New("database name must not be empty")
+		}
+		db.ClusterDatabaseName = d.client.config.Database
 	}
-	db.ClusterDatabaseName = d.client.config.Database
 
 	if len(db.ClusterDatabasePartitionTemplate) > MaxPartitions {
 		return fmt.Errorf("partition template should not have more than %d tags or tag buckets", MaxPartitions)

--- a/influxdb3/management_cloud_dedicated_test.go
+++ b/influxdb3/management_cloud_dedicated_test.go
@@ -47,6 +47,26 @@ func TestDedicatedClientCreateDatabase(t *testing.T) {
 		wantErr      bool
 	}{
 		{
+			name: "create database with defaults",
+			db: &Database{
+				ClusterDatabasePartitionTemplate: []PartitionTemplate{},
+			},
+			clientConfig: &ClientConfig{
+				Host:         "",
+				Token:        "my-token",
+				Organization: "default-organization",
+				Database:     "default-database",
+			},
+			wantBody: map[string]any{
+				"name":               "default-database",
+				"maxTables":          float64(500),
+				"maxColumnsPerTable": float64(250),
+				"retentionPeriod":    float64(0),
+				"partitionTemplate":  []any{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "create database with name and defaults",
 			db: &Database{
 				ClusterDatabaseName:              "test-database",
@@ -59,7 +79,7 @@ func TestDedicatedClientCreateDatabase(t *testing.T) {
 				Database:     "default-database",
 			},
 			wantBody: map[string]any{
-				"name":               "default-database",
+				"name":               "test-database",
 				"maxTables":          float64(500),
 				"maxColumnsPerTable": float64(250),
 				"retentionPeriod":    float64(0),
@@ -95,7 +115,7 @@ func TestDedicatedClientCreateDatabase(t *testing.T) {
 				Database:     "default-database",
 			},
 			wantBody: map[string]any{
-				"name":               "default-database",
+				"name":               "test-database",
 				"maxTables":          float64(1000),
 				"maxColumnsPerTable": float64(500),
 				"retentionPeriod":    float64(1000),


### PR DESCRIPTION
## Proposed Changes

Cloud Dedicated database creation ignores the database name given by an argument, but applies the database name within client configuration. This behavior differs from the API spec and user intuitions, so I'd say it's a bug.

## Checklist

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
