### PR TITLE
feat: expose http response headers in ServerError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.10.0 [unreleased]
 
+### Features
+
+1. [#100](https://github.com/InfluxCommunity/influxdb3-go/pull/100): Expose HTTP Response headers in `ServerError`
+
 ### Bug Fixes
 
 1. [#94](https://github.com/InfluxCommunity/influxdb3-go/pull/94): Resource leak from unclosed `Response`

--- a/examples/General/httpErrorHandled.go
+++ b/examples/General/httpErrorHandled.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/InfluxCommunity/influxdb3-go/influxdb3"
+)
+
+// Demonstrates working with HTTP response headers in ServerError
+func main() {
+	// Retrieve credentials from environment variables.
+	url := os.Getenv("INFLUX_URL")
+	token := os.Getenv("INFLUX_TOKEN")
+	database := os.Getenv("INFLUX_DATABASE")
+
+	// Instantiate a client using your credentials.
+	client, err := influxdb3.New(influxdb3.ClientConfig{
+		Host:     url,
+		Token:    token,
+		Database: database,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Close the client when finished and raise any errors.
+	defer func(client *influxdb3.Client) {
+		err := client.Close()
+		if err != nil {
+			panic(err)
+		}
+	}(client)
+
+	// Attempt to write line protocol synchronously
+	// N.B. faulty line protocol used here, because it
+	// guarantees a server error, but errors can be thrown
+	// for other reasons, such as 503 temporary unavailable
+	// or even 429 too many requests.
+	err = client.Write(context.Background(),
+		[]byte("air,sensor=HRF03,device_ID=42 humidity=67.1,temperature="))
+
+	if err != nil {
+		logMessage := "WARNING write error: " + err.Error()
+		logMessage += "\n   ServerError.Headers:\n"
+		var svErr *influxdb3.ServerError
+		errors.As(err, &svErr)
+		for key, value := range svErr.Headers {
+			logMessage += fmt.Sprintf("      %s: %s\n", key, value)
+		}
+		log.Println(logMessage)
+	}
+}

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -243,6 +243,8 @@ func (c *Client) resolveHTTPError(r *http.Response) error {
 		}
 	}
 
+	httpError.Headers = r.Header
+
 	return &httpError.ServerError
 }
 

--- a/influxdb3/error.go
+++ b/influxdb3/error.go
@@ -24,6 +24,7 @@ package influxdb3
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // ServerError represents an error returned from an InfluxDB API server.
@@ -36,6 +37,8 @@ type ServerError struct {
 	StatusCode int `json:"-"`
 	// RetryAfter holds the value of Retry-After header if sent by server, otherwise zero
 	RetryAfter int `json:"-"`
+	// Headers hold the response headers
+	Headers http.Header `json:"headers"`
 }
 
 // NewServerError returns new with just a message

--- a/influxdb3/example_write_test.go
+++ b/influxdb3/example_write_test.go
@@ -24,6 +24,7 @@ package influxdb3
 
 import (
 	"context"
+	"errors"
 	"log"
 	"strings"
 	"time"
@@ -121,5 +122,26 @@ func ExampleClient_WriteData() {
 	}))
 	if err != nil {
 		log.Fatal()
+	}
+}
+
+func ExampleClient_severError() {
+	client, err := NewFromEnv()
+	if err != nil {
+		log.Fatal()
+	}
+	defer client.Close()
+
+	err = client.Write(context.Background(),
+		[]byte("air,sensor=HRF03,device_ID=42 humidity=67.1,temperature="))
+
+	if err != nil {
+		log.Printf("WARN write failed: %s", err.Error())
+		var svErr *ServerError
+		errors.As(err, &svErr)
+		log.Printf("   ServerError headers:")
+		for key, val := range svErr.Headers {
+			log.Printf("    %s = %s", key, val)
+		}
 	}
 }

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -25,7 +25,6 @@ package influxdb3
 import (
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -759,9 +758,7 @@ func TestHttpErrorWithHeaders(t *testing.T) {
 	err = tc.WriteData(context.Background(), []any{})
 	require.Error(t, err)
 	var serr *ServerError
-	assert.NotPanics(t, func() {
-		errors.As(err, &serr)
-	})
+	require.ErrorAs(t, err, &serr)
 	assert.Equal(t, 400, serr.StatusCode)
 	assert.Equal(t, "Test Response", serr.Message)
 	assert.Len(t, serr.Headers, 6)

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -764,7 +764,7 @@ func TestHttpErrorWithHeaders(t *testing.T) {
 	})
 	assert.Equal(t, 400, serr.StatusCode)
 	assert.Equal(t, "Test Response", serr.Message)
-	assert.Equal(t, 6, len(serr.Headers))
+	assert.Len(t, serr.Headers, 6)
 	assert.Equal(t, traceID, serr.Headers["Trace-Id"][0])
 	assert.Equal(t, build, serr.Headers["X-Influxdb-Build"][0])
 	assert.Equal(t, tsVersion, serr.Headers["X-Influxdb-Version"][0])

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -733,6 +733,39 @@ func TestHttpError(t *testing.T) {
 	assert.ErrorContains(t, err, "error calling")
 }
 
+func TestHttpErrorWithHeaders(t *testing.T) {
+	traceID := "123456789ABCDEF0"
+	tsVersion := "v0.0.1"
+	build := "TestServer"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Trace-ID", traceID)
+		w.Header().Set("X-Influxdb-Build", build)
+		w.Header().Set("X-Influxdb-Version", tsVersion)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, err := w.Write([]byte("{ \"message\": \"Test Response\" }"))
+		if err != nil {
+			assert.FailNow(t, err.Error())
+		}
+	}))
+	defer ts.Close()
+	tc, err := New(ClientConfig{
+		Host:     ts.URL,
+		Token:    "my-token",
+		Database: "my-database",
+	})
+	require.NoError(t, err)
+	err = tc.WriteData(context.Background(), []any{})
+	require.Error(t, err)
+	assert.NotPanics(t, func() { _ = err.(*ServerError) })
+	assert.Equal(t, 400, err.(*ServerError).StatusCode)
+	assert.Equal(t, "Test Response", err.(*ServerError).Message)
+	assert.Equal(t, 6, len(err.(*ServerError).Headers))
+	assert.Equal(t, traceID, err.(*ServerError).Headers["Trace-Id"][0])
+	assert.Equal(t, build, err.(*ServerError).Headers["X-Influxdb-Build"][0])
+	assert.Equal(t, tsVersion, err.(*ServerError).Headers["X-Influxdb-Version"][0])
+}
+
 func TestWriteDatabaseNotSet(t *testing.T) {
 	p := NewPointWithMeasurement("cpu")
 	p.SetTag("host", "local")


### PR DESCRIPTION
## Proposed Changes

- Add `http.Header` to `ServerError`
- Add tests of this change
- Add examples of accessing response headers on write fail. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
