### PR TITLE
feature: allow Request.GetBody to be set when gzipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.13.0 [unreleased]
 
+### Features
+
+1. [#108](https://github.com/InfluxCommunity/influxdb3-go/pull/108): Allow Request.GetBody to be set when writing gzipped data to make calls more resilient.
+
 ## 0.12.0 [2024-10-02]
 
 ### Features


### PR DESCRIPTION
## Proposed Changes

Hello I am testing ``influxdb3`` to host my timeseries data. 

I am interacting with the DB using this library. I have one ``influxdb`` client shared among my ``go`` routines.  

I am regularely receiving errors of this kind when attempting to write data:

`http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error`

I noticed that the library does not allow for ``Request.Body`` to be set when gzipping is enabled. 

This change works around this to allow for more resilient client calls against influxdb3's HTTP/2 server. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)