### PR TITLE
feat: escape tabs in tag strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.0 [unreleased]
 
+1. [#111](https://github.com/InfluxCommunity/influxdb3-go/pull/111): Support tabs in tag values.
+
 ### Features
 
 1. [#108](https://github.com/InfluxCommunity/influxdb3-go/pull/108): Allow Request.GetBody to be set when writing gzipped data to make calls more resilient.

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -345,6 +345,8 @@ func TestEscapedStringValues(t *testing.T) {
 		map[string]string{
 			"tag1": "new\nline and space",
 			"tag2": "escaped\\nline and space",
+			"tag3": "escaped\nline and\ttab",
+			"tag4": "preescaped\\nline and\\ttab",
 		},
 		map[string]interface{}{
 			"fVal": 41.3,
@@ -359,5 +361,7 @@ func TestEscapedStringValues(t *testing.T) {
 		assert.EqualValues(t, "greetings\\nearthlings", qit.Value()["sVal"])
 		assert.EqualValues(t, "new\\nline and space", qit.Value()["tag1"])
 		assert.EqualValues(t, "escaped\\nline and space", qit.Value()["tag2"])
+		assert.EqualValues(t, "escaped\\nline and\\ttab", qit.Value()["tag3"])
+		assert.EqualValues(t, "preescaped\\nline and\\ttab", qit.Value()["tag4"])
 	}
 }

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -251,18 +251,10 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 	// N.B. Some customers have requested support for newline and tab chars in tag values (EAR 5476)
 	// Though this is outside the lineprotocol specification, it was supported in
 	// previous GO client versions.
-	tagEscapes := map[string]string{
-		"\n": "\\n",
-		"\t": "\\t",
-	}
-
-	replacer := func(reps map[string]string, s string) string {
-		result := s
-		for key, val := range reps {
-			result = strings.ReplaceAll(result, key, val)
-		}
-		return result
-	}
+	replacer := strings.NewReplacer(
+		"\n", "\\n",
+		"\t", "\\t",
+	)
 
 	// sort Tags
 	tagKeys := make([]string, 0, len(p.Values.Tags)+len(defaultTags))
@@ -287,9 +279,9 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 
 		// N.B. Some customers have requested support for newline and tab chars in tag values (EAR 5476)
 		if value, ok := p.Values.Tags[tagKey]; ok {
-			enc.AddTag(tagKey, replacer(tagEscapes, value))
+			enc.AddTag(tagKey, replacer.Replace(value))
 		} else {
-			enc.AddTag(tagKey, replacer(tagEscapes, defaultTags[tagKey]))
+			enc.AddTag(tagKey, replacer.Replace(defaultTags[tagKey]))
 		}
 	}
 

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -269,13 +269,18 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 		}
 		lastKey = tagKey
 
-		// N.B. Some customers have requested support for newline chars in tag values (EAR 5476)
+		// N.B. Some customers have requested support for newline and tab chars in tag values (EAR 5476)
 		// Though this is outside the lineprotocol specification, it was supported in
 		// previous GO client versions.
 		if value, ok := p.Values.Tags[tagKey]; ok {
-			enc.AddTag(tagKey, strings.ReplaceAll(value, "\n", "\\n"))
+			enc.AddTag(tagKey,
+				strings.ReplaceAll(
+					strings.ReplaceAll(value, "\t", "\\t"),
+					"\n", "\\n"))
 		} else {
-			enc.AddTag(tagKey, strings.ReplaceAll(defaultTags[tagKey], "\n", "\\n"))
+			enc.AddTag(tagKey, strings.ReplaceAll(
+				strings.ReplaceAll(defaultTags[tagKey], "\t", "\\t"),
+				"\n", "\\n"))
 		}
 	}
 

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -248,6 +248,22 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 	enc.SetPrecision(precision)
 	enc.StartLine(p.Values.MeasurementName)
 
+	// N.B. Some customers have requested support for newline and tab chars in tag values (EAR 5476)
+	// Though this is outside the lineprotocol specification, it was supported in
+	// previous GO client versions.
+	tagEscapes := map[string]string{
+		"\n": "\\n",
+		"\t": "\\t",
+	}
+
+	replacer := func(reps map[string]string, s string) string {
+		result := s
+		for key, val := range reps {
+			result = strings.ReplaceAll(result, key, val)
+		}
+		return result
+	}
+
 	// sort Tags
 	tagKeys := make([]string, 0, len(p.Values.Tags)+len(defaultTags))
 	for k := range p.Values.Tags {
@@ -270,17 +286,10 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 		lastKey = tagKey
 
 		// N.B. Some customers have requested support for newline and tab chars in tag values (EAR 5476)
-		// Though this is outside the lineprotocol specification, it was supported in
-		// previous GO client versions.
 		if value, ok := p.Values.Tags[tagKey]; ok {
-			enc.AddTag(tagKey,
-				strings.ReplaceAll(
-					strings.ReplaceAll(value, "\t", "\\t"),
-					"\n", "\\n"))
+			enc.AddTag(tagKey, replacer(tagEscapes, value))
 		} else {
-			enc.AddTag(tagKey, strings.ReplaceAll(
-				strings.ReplaceAll(defaultTags[tagKey], "\t", "\\t"),
-				"\n", "\\n"))
+			enc.AddTag(tagKey, replacer(tagEscapes, defaultTags[tagKey]))
 		}
 	}
 

--- a/influxdb3/point_test.go
+++ b/influxdb3/point_test.go
@@ -178,7 +178,7 @@ func TestPointDefaultTags(t *testing.T) {
 	assert.EqualValues(t, `test,tag1=a,tag2=b,tag3=f float64=80.1234567 60000000070`+"\n", string(line))
 }
 
-func TestPointWithNewlineTags(t *testing.T) {
+func TestPointWithEscapedTags(t *testing.T) {
 	p := NewPoint("test",
 		map[string]string{
 			"tag1":    "new\nline and space",

--- a/influxdb3/point_test.go
+++ b/influxdb3/point_test.go
@@ -184,6 +184,8 @@ func TestPointWithNewlineTags(t *testing.T) {
 			"tag1":    "new\nline and space",
 			"tag2":    "escaped\\nline and space",
 			"ambiTag": "ambiguous\ntag",
+			"tabTag1": "drink\tTab",
+			"tabTag2": "Tab\\tulator",
 		},
 		map[string]interface{}{
 			"fVal": 41.3,
@@ -198,16 +200,16 @@ func TestPointWithNewlineTags(t *testing.T) {
 	line, err := p.MarshalBinary(lineprotocol.Nanosecond)
 	require.NoError(t, err)
 	assert.EqualValues(t,
-		"test,ambiTag=ambiguous\\ntag,tag1=new\\nline\\ and\\ space,tag2=escaped\\nline\\ and\\ space "+
-			"fVal=41.3 60000000070\n",
+		"test,ambiTag=ambiguous\\ntag,tabTag1=drink\\tTab,tabTag2=Tab\\tulator,"+
+			"tag1=new\\nline\\ and\\ space,tag2=escaped\\nline\\ and\\ space fVal=41.3 60000000070\n",
 		string(line))
 
 	line, err = p.MarshalBinaryWithDefaultTags(lineprotocol.Nanosecond, defaultTags)
 	require.NoError(t, err)
 	assert.EqualValues(t,
-		"test,ambiTag=ambiguous\\ntag,defTag1=default\\nline\\ and\\ space,defTag2=escaped"+
-			"\\ndefault\\ line\\ and\\ space,tag1=new\\nline\\ and\\ space,tag2=escaped\\nline\\ and\\ space "+
-			"fVal=41.3 60000000070\n",
+		"test,ambiTag=ambiguous\\ntag,defTag1=default\\nline\\ and\\ space,"+
+			"defTag2=escaped\\ndefault\\ line\\ and\\ space,tabTag1=drink\\tTab,tabTag2=Tab\\tulator,"+
+			"tag1=new\\nline\\ and\\ space,tag2=escaped\\nline\\ and\\ space fVal=41.3 60000000070\n",
 		string(line))
 
 	pInvalid := NewPoint("test", map[string]string{


### PR DESCRIPTION
Related https://github.com/influxdata/EAR/issues/5476#issuecomment-2417071571

## Proposed Changes

- In `point.MarshallBinaryWithDefaultTags` add a mapping of strings to be escaped. 
- In same method add an internal method for iterating over map and escaping values in source string
- Rename `TestPointWithNewLineTags` to `TestPointWithEscapedTags`
- Add check in this and in `client_e2e_test` of tab (i.e. `\t`) escapes in tags. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
