### PR TITLE
chore: prepare v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Update steps:
 
 ## 1.0.0 [2024-11-15]
 
+:warning: **The v1.0.0 release had a malformed module path regarding the [Go Module Requirements](https://go.dev/ref/mod#major-version-suffixes). For a Go Module project, you need to use version 2 of the client.**
+
 ### Breaking Changes
 
 :warning: **This is a breaking change release.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 > Previously, the Query API did not respect the metadata type for columns returned from InfluxDB v3. This release fixes this issue. As a result, the type of some columns may differ from previous versions. For example, the timestamp column will now be `time.Time` instead of `arrow.Timestamp`.
 
 Update steps:
+
 1. Update library: `go get github.com/influxdata/influxdb3-go/v2`
 1. Update import path in Go files to `github.com/influxdata/influxdb3-go/v2/influxdb3`.
 
@@ -19,7 +20,7 @@ Update steps:
    - iox::column_type::field::float: => float64
    - iox::column_type::field::string: => string
    - iox::column_type::field::boolean: => bool
-   
+
 ## 1.0.0 [2024-11-15]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
-## 1.1.0 [unreleased]
+## 2.0.0 [unreleased]
 
+### Breaking Changes
+
+:warning: **This is a breaking change release.**
+
+> Previously, the Query API did not respect the metadata type for columns returned from InfluxDB v3. This release fixes this issue. As a result, the type of some columns may differ from previous versions. For example, the timestamp column will now be `time.Time` instead of `arrow.Timestamp`.
+
+Update steps:
+1. Update library: `go get github.com/influxdata/influxdb3-go/v2`
+1. Update import path in Go files to `github.com/influxdata/influxdb3-go/v2/influxdb3`.
+
+### Features
+
+1. [#114](https://github.com/InfluxCommunity/influxdb3-go/pull/114): Query API respects metadata types for columns returned from InfluxDB v3.
+   Tags are mapped as a "string", timestamp as "time.Time", and fields as their respective types:
+   - iox::column_type::field::integer: => int64
+   - iox::column_type::field::uinteger: => uint64
+   - iox::column_type::field::float: => float64
+   - iox::column_type::field::string: => string
+   - iox::column_type::field::boolean: => bool
+   
 ## 1.0.0 [2024-11-15]
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To use this client, you'll need the following credentials for writing and queryi
 <!--pytest-codeblocks:cont-->
 
    ```sh
-   go get github.com/InfluxCommunity/influxdb3-go
+   go get github.com/InfluxCommunity/influxdb3-go/v2
    ```
 
 ### Outside a module (standalone)
@@ -79,7 +79,7 @@ import (
   "fmt"
   "os"
 
-  "github.com/InfluxCommunity/influxdb3-go/influxdb3/v1"
+  "github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 ```
 

--- a/examples/Basic/basic.go
+++ b/examples/Basic/basic.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func main() {

--- a/examples/Batching/batching.go
+++ b/examples/Batching/batching.go
@@ -8,8 +8,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3/batching"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3/batching"
 )
 
 const NumPoints = 54

--- a/examples/Downsampling/downsampling.go
+++ b/examples/Downsampling/downsampling.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 func main() {

--- a/examples/HTTPErrorHandled/httpErrorHandled.go
+++ b/examples/HTTPErrorHandled/httpErrorHandled.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 // Demonstrates working with HTTP response headers in ServerError

--- a/examples/LPBatching/lpBatching.go
+++ b/examples/LPBatching/lpBatching.go
@@ -9,8 +9,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3/batching"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3/batching"
 )
 
 const LineCount = 100

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/InfluxCommunity/influxdb3-go/v1
+module github.com/InfluxCommunity/influxdb3-go/v2
 
 go 1.22.7
 

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -28,7 +28,7 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 )
 
 // DefaultBatchSize is the default number of points emitted

--- a/influxdb3/batching/batcher_test.go
+++ b/influxdb3/batching/batcher_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/influxdb3/batching/example_test.go
+++ b/influxdb3/batching/example_test.go
@@ -29,8 +29,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3/batching"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3/batching"
 )
 
 func Example_batcher() {

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -37,8 +37,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3"
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3/batching"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3/batching"
 	"github.com/influxdata/line-protocol/v2/lineprotocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -33,7 +33,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/InfluxCommunity/influxdb3-go/v1/influxdb3/gzip"
+	"github.com/InfluxCommunity/influxdb3-go/v2/influxdb3/gzip"
 	"github.com/influxdata/line-protocol/v2/lineprotocol"
 )
 


### PR DESCRIPTION
## Proposed Changes

The last major release v1.0.0 with module suffix /v1 can not be used. We have to update to v2

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
