### PR TITLE
fix: LPBatcher issue - lines longer than the buffer size lead to emitting 0 size packets and unemptied buffer

### DIFF
--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -172,14 +172,6 @@ func (lpb *LPBatcher) emitBytes() []byte {
 		return lpb.buffer
 	}
 
-	// with no '\n' record separator
-	// just emit whole buffer
-	if firstLF == -1 {
-		packet = lpb.buffer
-		lpb.buffer = lpb.buffer[:0]
-		return packet
-	}
-
 	// With first line larger than defined size
 	// just emit first line
 	if firstLF > lpb.size {


### PR DESCRIPTION
## Proposed Changes

Motivated by EAR 5762

In `LPBatcher.emitBytes()`
   * Check whether the first line exceeds the buffer size.
   * If it does, just emit the first line and adjust the buffer accordingly
   * If not, proceed with emitting the packet and correct the buffer as before

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
