### PR TITLE
fix: remove unnecessary toolchain includes and set the minimum Go version to 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.2.0 [unreleased]
 
+### Bug fixes
+
+1. [#134](https://github.com/InfluxCommunity/influxdb3-go/pull/134): Reduce minimal Go version to 1.22, remove unnecessary toolchain constraints.
+
 ## 2.1.0 [2025-01-16]
 
 ### Bug fixes

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/InfluxCommunity/influxdb3-go/v2
 
-go 1.22.7
-
-toolchain go1.22.9
+go 1.22
 
 require (
 	github.com/apache/arrow/go/v15 v15.0.2


### PR DESCRIPTION
Closes #133 

## Proposed Changes

Drop "minimum virus" which comes from grpc-go ... for more info see #133.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
