### PR TITLE
feat: configurable http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 1. [#146](https://github.com/InfluxCommunity/influxdb3-go/pull/146): Add error field to QueryIterator to hold first possible error encountered when retrieving records from the flight Reader.
-2. [#147](https://github.com/InfluxCommunity/influxdb3-go/pull/147): Ability to pass `grpc.CallOption` functions to the underlying flight Client.
+1. [#147](https://github.com/InfluxCommunity/influxdb3-go/pull/147): Ability to pass `grpc.CallOption` functions to the underlying flight Client.
 1. [#149](https://github.com/InfluxCommunity/influxdb3-go/pull/149): Fix built-in HTTP client's default configuration and expose some configuration options.
 
 ## 2.4.0 [2025-03-26]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#146](https://github.com/InfluxCommunity/influxdb3-go/pull/146): Add error field to QueryIterator to hold first possible error encountered when retrieving records from the flight Reader.
+1. [#149](https://github.com/InfluxCommunity/influxdb3-go/pull/149): Fix built-in HTTP client's default configuration and expose some configuration options.
 
 ## 2.4.0 [2025-03-26]
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Replace the following with your own [credentials](#influxdb-v3-credentials):
 ### Configure connection
 
 The `influxdb3.Client` internally uses 2 client libraries to communicate with an InfluxDB v3 instance:
+
 - `http.Client` (`net/http`) - HTTP client for write operations
 - `flight.Client` (`github.com/apache/arrow/go/v15/arrow/flight`) - GRPC client for query operations
 

--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ The `influxdb3.Client` internally uses 2 client libraries to communicate with an
 
 #### Configuration of http.Client
 
-| ClientConfig Key        | Description                                                                                                                                     |
-|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| `HTTPClient`            | A custom configured `http.Client` instance can be provided. If set this client instance will be used for write operations.                      |  
-| `Timeout`               | The overall time limit for requests made by the Client. A negative value means no timeout. Default value: 10 seconds.                           |
-| `IdleConnectionTimeout` | Maximum amount of time an idle connection will remain idle before closing itself. A negative value means no timeout. Default value: 90 seconds. |
-| `MaxIdleConnections`    | Maximum number of idle connections. A negative value means no limit. Default value: 100.                                                        |
+| ClientConfig Key        | Description                                                                                                                                                                          |
+|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HTTPClient`            | A custom configured `http.Client` instance can be provided. If set this client instance will be used for write operations.                                                           |  
+| `Timeout`               | The overall time limit for requests made by the Client. A negative value means no timeout. Default value: 10 seconds.                                                                |
+| `IdleConnectionTimeout` | Maximum amount of time an idle connection will remain idle before closing itself. A negative value means no timeout. Default value: 90 seconds.                                      |
+| `MaxIdleConnections`    | Maximum number of idle connections. It sets both `transport.MaxIdleConn` and `transport.MaxIdleConnsPerHost` to the same value. A negative value means no limit. Default value: 100. |
 
 ### Close the client
 

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -137,24 +137,7 @@ func New(config ClientConfig) (*Client, error) {
 		c.config.HTTPClient = newHTTPClient(config)
 	} else {
 		// HTTPClient provided by the user.
-		httpClient := c.config.HTTPClient
-		if config.isTimeoutSet() {
-			httpClient.Timeout = config.getTimeoutOrDefault()
-		}
-		if config.isIdleConnectionTimeoutSet() {
-			ensureTransportSet(httpClient, config)
-			if transport, ok := httpClient.Transport.(*http.Transport); ok {
-				transport.IdleConnTimeout = config.getIdleConnectionTimeoutOrDefault()
-			}
-		}
-		if config.isMaxIdleConnectionsSet() {
-			ensureTransportSet(httpClient, config)
-			if transport, ok := httpClient.Transport.(*http.Transport); ok {
-				maxIdleConnections := config.getMaxIdleConnectionsOrDefault()
-				transport.MaxIdleConns = maxIdleConnections
-				transport.MaxIdleConnsPerHost = maxIdleConnections
-			}
-		}
+		configureHTTPClient(c.config.HTTPClient, config)
 	}
 	if certPool != nil {
 		setHTTPClientCertPool(c.config.HTTPClient, certPool, config)
@@ -205,6 +188,27 @@ func newHTTPClient(config ClientConfig) *http.Client {
 	return &http.Client{
 		Timeout:   timeout,
 		Transport: newHTTPTransport(config),
+	}
+}
+
+// configureHTTPClient configures existing HTTPClient based on ClientConfig.
+func configureHTTPClient(httpClient *http.Client, config ClientConfig) {
+	if config.isTimeoutSet() {
+		httpClient.Timeout = config.getTimeoutOrDefault()
+	}
+	if config.isIdleConnectionTimeoutSet() {
+		ensureTransportSet(httpClient, config)
+		if transport, ok := httpClient.Transport.(*http.Transport); ok {
+			transport.IdleConnTimeout = config.getIdleConnectionTimeoutOrDefault()
+		}
+	}
+	if config.isMaxIdleConnectionsSet() {
+		ensureTransportSet(httpClient, config)
+		if transport, ok := httpClient.Transport.(*http.Transport); ok {
+			maxIdleConnections := config.getMaxIdleConnectionsOrDefault()
+			transport.MaxIdleConns = maxIdleConnections
+			transport.MaxIdleConnsPerHost = maxIdleConnections
+		}
 	}
 }
 

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/influxdata/line-protocol/v2/lineprotocol"
 )
@@ -50,6 +51,15 @@ const (
 	connStrInfluxDatabase      = "database"
 	connStrInfluxPrecision     = "precision"
 	connStrInfluxGzipThreshold = "gzipThreshold"
+)
+
+const (
+	// defaultTimeout specifies the default value of ClientConfig.Timeout.
+	defaultTimeout = 10 * time.Second
+	// defaultIdleConnectionTimeout specifies the default value of ClientConfig.IdleConnectionTimeout.
+	defaultIdleConnectionTimeout = 90 * time.Second
+	// defaultMaxIdleConnections specifies the default value of ClientConfig.MaxIdleConnections.
+	defaultMaxIdleConnections = 100
 )
 
 // ClientConfig holds the parameters for creating a new client.
@@ -81,8 +91,32 @@ type ClientConfig struct {
 	// (TLSClientConfig), a custom request timeout (Timeout),
 	// or other customization as required.
 	//
-	// It HTTPClient is nil, http.DefaultClient will be used.
+	// If HTTPClient is nil, http.DefaultClient will be used with the following adjustments:
+	//   - Timeout: 10s
+	//   - Transport.IdleConnTimeout: 90s
+	//   - Transport.MaxIdleConns: 100
+	//   - Transport.MaxIdleConnsPerHost: 100
 	HTTPClient *http.Client
+
+	// Timeout specifies the overall time limit for requests made by the Client.
+	// The timeout includes connection time, any redirects, and reading the response body.
+	// It is applied to write (HTTP client) operations only.
+	//
+	// A negative value means no timeout. Default value: 10 seconds.
+	Timeout time.Duration
+
+	// IdleConnectionTimeout specifies the maximum amount of time an idle connection
+	// will remain idle before closing itself.
+	// It is applied to write (HTTP client) operations only.
+	//
+	// A negative value means no timeout. Default value: 90 seconds.
+	IdleConnectionTimeout time.Duration
+
+	// MaxIdleConnections controls the maximum number of idle connections.
+	// It is applied to write (HTTP client) operations only.
+	//
+	// A negative value means no limit. Default value: 100.
+	MaxIdleConnections int
 
 	// Write options
 	WriteOptions *WriteOptions
@@ -95,6 +129,9 @@ type ClientConfig struct {
 
 	// Proxy URL
 	Proxy string
+}
+
+type HTTPClientConfig struct {
 }
 
 // validate validates the config.
@@ -220,4 +257,58 @@ func (c *ClientConfig) parseGzipThreshold(threshold string) error {
 	c.WriteOptions.GzipThreshold = value
 
 	return nil
+}
+
+// isTimeoutSet returns whether the Timeout was set.
+func (c *ClientConfig) isTimeoutSet() bool {
+	return c.Timeout != 0
+}
+
+// getTimeoutOrDefault returns the Timeout or the default value if not set.
+func (c *ClientConfig) getTimeoutOrDefault() time.Duration {
+	if c.Timeout == 0 {
+		// Not set, use the default.
+		return defaultTimeout
+	}
+	if c.Timeout < 0 {
+		// No timeout.
+		return 0
+	}
+	return c.Timeout
+}
+
+// isIdleConnectionTimeoutSet returns whether the IdleConnectionTimeout was set.
+func (c *ClientConfig) isIdleConnectionTimeoutSet() bool {
+	return c.IdleConnectionTimeout != 0
+}
+
+// getIdleConnectionTimeoutOrDefault returns the IdleConnectionTimeout or the default value if not set.
+func (c *ClientConfig) getIdleConnectionTimeoutOrDefault() time.Duration {
+	if c.IdleConnectionTimeout == 0 {
+		// Not set, use the default.
+		return defaultIdleConnectionTimeout
+	}
+	if c.IdleConnectionTimeout < 0 {
+		// No timeout.
+		return 0
+	}
+	return c.IdleConnectionTimeout
+}
+
+// isMaxIdleConnectionsSet returns whether the MaxIdleConnections was set.
+func (c *ClientConfig) isMaxIdleConnectionsSet() bool {
+	return c.MaxIdleConnections != 0
+}
+
+// getMaxIdleConnectionsOrDefault returns the MaxIdleConnections or the default value if not set.
+func (c *ClientConfig) getMaxIdleConnectionsOrDefault() int {
+	if c.MaxIdleConnections == 0 {
+		// Not set, use the default.
+		return defaultMaxIdleConnections
+	}
+	if c.MaxIdleConnections < 0 {
+		// No limit.
+		return 0
+	}
+	return c.MaxIdleConnections
 }

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -131,9 +131,6 @@ type ClientConfig struct {
 	Proxy string
 }
 
-type HTTPClientConfig struct {
-}
-
 // validate validates the config.
 func (c *ClientConfig) validate() error {
 	if c.Host == "" {

--- a/influxdb3/example_query_test.go
+++ b/influxdb3/example_query_test.go
@@ -25,6 +25,7 @@ package influxdb3
 import (
 	"context"
 	"log"
+	"time"
 )
 
 func ExampleClient_Query() {
@@ -34,8 +35,13 @@ func ExampleClient_Query() {
 	}
 	defer client.Close()
 
+	// configure client timeout via context
+	clientTimeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), clientTimeout)
+	defer cancel()
+
 	// query
-	iterator, _ := client.Query(context.Background(),
+	iterator, _ := client.Query(ctx,
 		"SELECT count(*) FROM weather WHERE time >= now() - interval '5 minutes'")
 
 	for iterator.Next() {
@@ -43,7 +49,7 @@ func ExampleClient_Query() {
 	}
 
 	// query with custom header
-	iterator, _ = client.Query(context.Background(),
+	iterator, _ = client.Query(ctx,
 		"SELECT count(*) FROM stat WHERE time >= now() - interval '5 minutes'",
 		WithHeader("X-trace-ID", "#0122"))
 
@@ -59,8 +65,13 @@ func ExampleClient_QueryWithParameters() {
 	}
 	defer client.Close()
 
+	// configure client timeout via context
+	clientTimeout := 10 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), clientTimeout)
+	defer cancel()
+
 	// query
-	iterator, _ := client.QueryWithParameters(context.Background(),
+	iterator, _ := client.QueryWithParameters(ctx,
 		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
 		QueryParameters{
 			"location": "sun-valley-1",
@@ -71,7 +82,7 @@ func ExampleClient_QueryWithParameters() {
 	}
 
 	// query with custom header
-	iterator, _ = client.QueryWithParameters(context.Background(),
+	iterator, _ = client.QueryWithParameters(ctx,
 		"SELECT count(*) FROM weather WHERE location = $location AND time >= now() - interval '5 minutes'",
 		QueryParameters{
 			"location": "sun-valley-1",

--- a/influxdb3/example_test.go
+++ b/influxdb3/example_test.go
@@ -24,6 +24,7 @@ package influxdb3
 
 import (
 	"log"
+	"time"
 )
 
 func ExampleNew() {
@@ -33,6 +34,10 @@ func ExampleNew() {
 		Database:         "my-database",
 		SSLRootsFilePath: "/path/to/certificates.pem",
 		Proxy:            "http://localhost:8888",
+		// Connection parameters:
+		Timeout:               10 * time.Second,
+		IdleConnectionTimeout: 90 * time.Second,
+		MaxIdleConnections:    10,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -146,10 +146,6 @@ func WithDefaultTags(tags map[string]string) Option {
 //	   )
 //
 // For more information see https://pkg.go.dev/google.golang.org/grpc#CallOption
-//
-//nolint:gci
-//nolint:gofmt
-//nolint:goimports
 func WithGrpcCallOption(grpcCallOption grpc.CallOption) Option {
 	return func(o *options) {
 		o.QueryOptions.GrpcCallOptions = append(o.QueryOptions.GrpcCallOptions, grpcCallOption)

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -28,8 +28,10 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -501,23 +503,7 @@ func TestWritePointsWithOptions(t *testing.T) {
 
 func TestWriteData(t *testing.T) {
 	now := time.Now()
-	s := struct {
-		Measurement string    `lp:"measurement"`
-		Sensor      string    `lp:"tag,sensor"`
-		ID          string    `lp:"tag,device_id"`
-		Temp        float64   `lp:"field,temperature"`
-		Hum         int       `lp:"field,humidity"`
-		Time        time.Time `lp:"timestamp"`
-		Description string    `lp:"-"`
-	}{
-		"air",
-		"SHT31",
-		"10",
-		23.5,
-		55,
-		now,
-		"Room temp",
-	}
+	s := sampleDataStruct(now)
 	lp := fmt.Sprintf("air,device_id=10,sensor=SHT31 humidity=55i,temperature=23.5 %d\n", now.UnixNano())
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// initialization of query client
@@ -538,6 +524,35 @@ func TestWriteData(t *testing.T) {
 	require.NoError(t, err)
 	err = c.WriteData(context.Background(), []any{s})
 	assert.NoError(t, err)
+}
+
+func sampleDataStruct(now time.Time) struct {
+	Measurement string `lp:"measurement"`
+	Sensor      string `lp:"tag,sensor"`
+	ID          string `lp:"tag,device_id"`
+
+	Temp        float64   `lp:"field,temperature"`
+	Hum         int       `lp:"field,humidity"`
+	Time        time.Time `lp:"timestamp"`
+	Description string    `lp:"-"`
+} {
+	return struct {
+		Measurement string    `lp:"measurement"`
+		Sensor      string    `lp:"tag,sensor"`
+		ID          string    `lp:"tag,device_id"`
+		Temp        float64   `lp:"field,temperature"`
+		Hum         int       `lp:"field,humidity"`
+		Time        time.Time `lp:"timestamp"`
+		Description string    `lp:"-"`
+	}{
+		"air",
+		"SHT31",
+		"10",
+		23.5,
+		55,
+		now,
+		"Room temp",
+	}
 }
 
 func TestWriteEmptyData(t *testing.T) {
@@ -919,4 +934,98 @@ func TestMakeHTTPParamsBody(t *testing.T) {
 
 		assert.Equal(t, string(slurp1), string(slurp2))
 	}
+}
+
+func TestWriteWithClientTimeout(t *testing.T) {
+	timeout := 500 * time.Millisecond
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(timeout + 1*time.Second)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+	c, err := New(ClientConfig{
+		Host:     ts.URL,
+		Token:    "my-token",
+		Database: "my-database",
+		Timeout:  timeout,
+	})
+	require.NoError(t, err)
+
+	err = c.Write(context.Background(), []byte("data"))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+
+	p := NewPointWithMeasurement("cpu")
+	p.SetTag("host", "local")
+	p.SetField("usage_user", 16.75)
+	err = c.WritePoints(context.Background(), []*Point{p})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+
+	now := time.Now()
+	s := sampleDataStruct(now)
+	err = c.WriteData(context.Background(), []any{s})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
+func TestWriteWithMaxIdleConnections(t *testing.T) {
+	requestCount := 0
+	uniqueConnectionCount := 0
+	var addrMap sync.Map
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// initialization of query client
+		if r.Method == "PRI" {
+			return
+		}
+		requestCount++
+		addr := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+		_, loaded := addrMap.LoadOrStore(addr, true)
+		if !loaded {
+			uniqueConnectionCount++
+		}
+		// Add some sleep time to ensure that all parallel requests reach the server before any of them finishes.
+		time.Sleep(1 * time.Second)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	maxIdleConnections := 2
+	c, err := New(ClientConfig{
+		Host:               ts.URL,
+		Token:              "my-token",
+		Database:           "my-database",
+		MaxIdleConnections: maxIdleConnections,
+	})
+	require.NoError(t, err)
+
+	writeInParallel := func(callCount int) {
+		var wg sync.WaitGroup
+		wg.Add(callCount)
+		for i := 1; i <= callCount; i++ {
+			go func() {
+				defer wg.Done()
+				err := c.Write(context.Background(), []byte("data"))
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+	}
+
+	// 1st batch: do 5 writes in parallel to open 5 new connections.
+	batch1Count := 5
+	writeInParallel(batch1Count)
+
+	// Check that 5 unique connections were used.
+	assert.Equal(t, batch1Count, uniqueConnectionCount)
+	assert.Equal(t, batch1Count, requestCount)
+
+	// 2nd batch: do another 5 writes in parallel.
+	batch2Count := 5
+	writeInParallel(batch2Count)
+
+	// Check that only 5+3 unique connections were used (instead of 5+5)
+	// as 2 idle connections were reused from the 1st batch.
+	assert.Equal(t, batch1Count+batch2Count-maxIdleConnections, uniqueConnectionCount)
+	assert.Equal(t, batch1Count+batch2Count, requestCount)
 }

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -979,7 +979,10 @@ func TestWriteWithMaxIdleConnections(t *testing.T) {
 			return
 		}
 		requestCount++
-		addr := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+		addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+		if !ok {
+			t.Errorf("could not get local address from context: %v", addr)
+		}
 		_, loaded := addrMap.LoadOrStore(addr, true)
 		if !loaded {
 			uniqueConnectionCount++


### PR DESCRIPTION
Closes https://github.com/InfluxCommunity/influxdb3-go/issues/144

## Proposed Changes

InfluxDB 3 Go client uses a wrapped `http.Client` for **write** operations (for queries GRPC client is used). This `http.Client` supports connection pooling but unfortunately the used default configuration is unacceptable for production use. This PR focuses on the main configuration issues of this HTTP client.

- Fixing the following issues of the wrapped `http.Client`:
  - default `Timeout` was set to unlimited, so if a connection was pending then the client was waiting forever
  - default `MaxIdleConnsPerHost` was set to `2` which highly limited the connection reuse
- Introduced new configuration options to configure the wrapped `http.Client`:
  - `Timeout` - sets `Timeout`, default: `10s`
  - `IdleConnectionTimeout` - sets `transport.IdleConnTimeout`, default: `90s`
  -  `MaxIdleConnections` - sets `transport.MaxIdleConns` and `transport.MaxIdleConnsPerHost`, default: `100`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
