### PR TITLE
feat: change iterators to interface type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.0.0 [unreleased]
+
+### Breaking Changes
+
+:warning: **This is a breaking change release.**
+
+> To improve mockability, `QueryIterator` and `PointValueIterator` were changed from `struct` type to `interface` type.
+
+Update steps:
+
+1. Update library: `go get github.com/InfluxCommunity/influxdb3-go/v3/influxdb3`
+1. Update import path in Go files to `github.com/InfluxCommunity/influxdb3-go/v3/influxdb3`
+1. Replace all occurrences of `*QueryIterator` with `QueryIterator` in your code
+1. Replace all occurrences of `*PointValueIterator` with `PointValueIterator` in your code
+
+### Features
+
+1. [#150](https://github.com/InfluxCommunity/influxdb3-go/pull/150): `QueryIterator` and `PointValueIterator` were changed to `interface` type.
+
 ## 2.5.0 [unreleased]
 
 ### Features

--- a/influxdb3/point_value_iterator.go
+++ b/influxdb3/point_value_iterator.go
@@ -67,6 +67,8 @@ type defaultPointValueIterator struct {
 }
 
 // Return a new defaultPointValueIterator
+//
+//nolint:ireturn
 func newDefaultPointValueIterator(reader *flight.Reader) PointValueIterator {
 	return &defaultPointValueIterator{
 		reader: reader,

--- a/influxdb3/point_value_iterator_test.go
+++ b/influxdb3/point_value_iterator_test.go
@@ -122,7 +122,7 @@ func TestPointValueIterator(t *testing.T) {
 	assert.NoError(t, err)
 
 	fReader := &flight.Reader{Reader: ipcReader}
-	it := newPointValueIterator(fReader)
+	it := newDefaultPointValueIterator(fReader)
 
 	var resultSet0 []int64
 	var resultSet1 []interface{}
@@ -241,7 +241,7 @@ func TestPointValueIteratorError(t *testing.T) {
 
 	fReader := &flight.Reader{Reader: mockReader}
 
-	it := newPointValueIterator(fReader)
+	it := newDefaultPointValueIterator(fReader)
 
 	values, err := it.Next()
 

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -98,6 +98,8 @@ type QueryParameters = map[string]any
 // Returns:
 //   - A result iterator (QueryIterator).
 //   - An error, if any.
+//
+//nolint:ireturn
 func (c *Client) Query(ctx context.Context, query string, options ...QueryOption) (QueryIterator, error) {
 	return c.query(ctx, query, nil, newQueryOptions(&DefaultQueryOptions, options))
 }
@@ -111,6 +113,8 @@ func (c *Client) Query(ctx context.Context, query string, options ...QueryOption
 // Returns:
 //   - A result iterator (PointValueIterator).
 //   - An error, if any.
+//
+//nolint:ireturn
 func (c *Client) QueryPointValue(ctx context.Context, query string, options ...QueryOption) (PointValueIterator, error) {
 	return c.queryPointValue(ctx, query, nil, newQueryOptions(&DefaultQueryOptions, options))
 }
@@ -125,6 +129,8 @@ func (c *Client) QueryPointValue(ctx context.Context, query string, options ...Q
 // Returns:
 //   - A result iterator (QueryIterator).
 //   - An error, if any.
+//
+//nolint:ireturn
 func (c *Client) QueryWithParameters(ctx context.Context, query string, parameters QueryParameters,
 	options ...QueryOption) (QueryIterator, error) {
 	return c.query(ctx, query, parameters, newQueryOptions(&DefaultQueryOptions, options))
@@ -140,6 +146,8 @@ func (c *Client) QueryWithParameters(ctx context.Context, query string, paramete
 // Returns:
 //   - A result iterator (PointValueIterator).
 //   - An error, if any.
+//
+//nolint:ireturn
 func (c *Client) QueryPointValueWithParameters(ctx context.Context, query string, parameters QueryParameters,
 	options ...QueryOption) (PointValueIterator, error) {
 	return c.queryPointValue(ctx, query, parameters, newQueryOptions(&DefaultQueryOptions, options))
@@ -156,6 +164,8 @@ func (c *Client) QueryPointValueWithParameters(ctx context.Context, query string
 //   - An error, if any.
 //
 // Deprecated: use Query with variadic QueryOption options.
+//
+//nolint:ireturn
 func (c *Client) QueryWithOptions(ctx context.Context, options *QueryOptions, query string) (QueryIterator, error) {
 	if options == nil {
 		return nil, errors.New("options not set")
@@ -164,6 +174,7 @@ func (c *Client) QueryWithOptions(ctx context.Context, options *QueryOptions, qu
 	return c.query(ctx, query, nil, options)
 }
 
+//nolint:ireturn
 func (c *Client) query(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (QueryIterator, error) {
 	reader, err := c.getReader(ctx, query, parameters, options)
 	if err != nil {
@@ -173,6 +184,7 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 	return newDefaultQueryIterator(reader), nil
 }
 
+//nolint:ireturn
 func (c *Client) queryPointValue(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (PointValueIterator, error) {
 	reader, err := c.getReader(ctx, query, parameters, options)
 	if err != nil {

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -96,9 +96,9 @@ type QueryParameters = map[string]any
 //   - options: The optional query options. See QueryOption for available options.
 //
 // Returns:
-//   - A result iterator (*QueryIterator).
+//   - A result iterator (QueryIterator).
 //   - An error, if any.
-func (c *Client) Query(ctx context.Context, query string, options ...QueryOption) (*QueryIterator, error) {
+func (c *Client) Query(ctx context.Context, query string, options ...QueryOption) (QueryIterator, error) {
 	return c.query(ctx, query, nil, newQueryOptions(&DefaultQueryOptions, options))
 }
 
@@ -109,9 +109,9 @@ func (c *Client) Query(ctx context.Context, query string, options ...QueryOption
 //   - options: The optional query options. See QueryOption for available options.
 //
 // Returns:
-//   - A result iterator (*PointValueIterator).
+//   - A result iterator (PointValueIterator).
 //   - An error, if any.
-func (c *Client) QueryPointValue(ctx context.Context, query string, options ...QueryOption) (*PointValueIterator, error) {
+func (c *Client) QueryPointValue(ctx context.Context, query string, options ...QueryOption) (PointValueIterator, error) {
 	return c.queryPointValue(ctx, query, nil, newQueryOptions(&DefaultQueryOptions, options))
 }
 
@@ -123,10 +123,10 @@ func (c *Client) QueryPointValue(ctx context.Context, query string, options ...Q
 //   - options: The optional query options. See QueryOption for available options.
 //
 // Returns:
-//   - A result iterator (*QueryIterator).
+//   - A result iterator (QueryIterator).
 //   - An error, if any.
 func (c *Client) QueryWithParameters(ctx context.Context, query string, parameters QueryParameters,
-	options ...QueryOption) (*QueryIterator, error) {
+	options ...QueryOption) (QueryIterator, error) {
 	return c.query(ctx, query, parameters, newQueryOptions(&DefaultQueryOptions, options))
 }
 
@@ -138,10 +138,10 @@ func (c *Client) QueryWithParameters(ctx context.Context, query string, paramete
 //   - options: The optional query options. See QueryOption for available options.
 //
 // Returns:
-//   - A result iterator (*PointValueIterator).
+//   - A result iterator (PointValueIterator).
 //   - An error, if any.
 func (c *Client) QueryPointValueWithParameters(ctx context.Context, query string, parameters QueryParameters,
-	options ...QueryOption) (*PointValueIterator, error) {
+	options ...QueryOption) (PointValueIterator, error) {
 	return c.queryPointValue(ctx, query, parameters, newQueryOptions(&DefaultQueryOptions, options))
 }
 
@@ -152,11 +152,11 @@ func (c *Client) QueryPointValueWithParameters(ctx context.Context, query string
 //   - query: The query string to execute.
 //
 // Returns:
-//   - A result iterator (*QueryIterator).
+//   - A result iterator (QueryIterator).
 //   - An error, if any.
 //
 // Deprecated: use Query with variadic QueryOption options.
-func (c *Client) QueryWithOptions(ctx context.Context, options *QueryOptions, query string) (*QueryIterator, error) {
+func (c *Client) QueryWithOptions(ctx context.Context, options *QueryOptions, query string) (QueryIterator, error) {
 	if options == nil {
 		return nil, errors.New("options not set")
 	}
@@ -164,22 +164,22 @@ func (c *Client) QueryWithOptions(ctx context.Context, options *QueryOptions, qu
 	return c.query(ctx, query, nil, options)
 }
 
-func (c *Client) query(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (*QueryIterator, error) {
+func (c *Client) query(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (QueryIterator, error) {
 	reader, err := c.getReader(ctx, query, parameters, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return newQueryIterator(reader), nil
+	return newDefaultQueryIterator(reader), nil
 }
 
-func (c *Client) queryPointValue(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (*PointValueIterator, error) {
+func (c *Client) queryPointValue(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (PointValueIterator, error) {
 	reader, err := c.getReader(ctx, query, parameters, options)
 	if err != nil {
 		return nil, err
 	}
 
-	return newPointValueIterator(reader), nil
+	return newDefaultPointValueIterator(reader), nil
 }
 
 func (c *Client) getReader(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (*flight.Reader, error) {

--- a/influxdb3/query_iterator.go
+++ b/influxdb3/query_iterator.go
@@ -119,6 +119,7 @@ type defaultQueryIterator struct {
 	done bool
 }
 
+//nolint:ireturn
 func newDefaultQueryIterator(reader *flight.Reader) QueryIterator {
 	return &defaultQueryIterator{
 		reader:        reader,

--- a/influxdb3/query_iterator_test.go
+++ b/influxdb3/query_iterator_test.go
@@ -53,7 +53,7 @@ func TestQueryIteratorEmptyRecord(t *testing.T) {
 	assert.NoError(t, err)
 
 	fReader := &flight.Reader{Reader: ipcReader}
-	it := newQueryIterator(fReader)
+	it := newDefaultQueryIterator(fReader).(*defaultQueryIterator)
 
 	count := 0
 	for it.Next() {
@@ -76,7 +76,7 @@ func TestQueryIteratorError(t *testing.T) {
 
 	fReader := &flight.Reader{Reader: mockReader}
 
-	testIT := newQueryIterator(fReader)
+	testIT := newDefaultQueryIterator(fReader)
 	assert.False(t, testIT.Next(), "iterator should have no next record")
 	assert.Equal(t, testIT.Err().Error(), errorMessage)
 }

--- a/influxdb3/query_iterator_test.go
+++ b/influxdb3/query_iterator_test.go
@@ -53,7 +53,10 @@ func TestQueryIteratorEmptyRecord(t *testing.T) {
 	assert.NoError(t, err)
 
 	fReader := &flight.Reader{Reader: ipcReader}
-	it := newDefaultQueryIterator(fReader).(*defaultQueryIterator)
+	it, ok := newDefaultQueryIterator(fReader).(*defaultQueryIterator)
+	if !ok {
+		t.Error("expected defaultQueryIterator")
+	}
 
 	count := 0
 	for it.Next() {


### PR DESCRIPTION
**TODO: let's wait until other PRs are merged and released then merge this PR!**

Closes #145

## Proposed Changes

**[BREAKING CHANGE]** To improve mockability, `QueryIterator` and `PointValueIterator` were changed from `struct` type to `interface` type.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
