### PR TITLE
feat: export NewQueryIterator and NewPointValueIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
      means no timeout. Default value: 90 seconds.
    - `MaxIdleConnections`  - Maximum number of idle connections. It sets both `transport.MaxIdleConn` and
      `transport.MaxIdleConnsPerHost` to the same value. A negative value means no limit. Default value: 100.
+1. [#154](https://github.com/InfluxCommunity/influxdb3-go/pull/154): Export functions `NewQueryIterator` and
+   `NewPointValueIterator` to simplify testing.
 
 ## 2.4.0 [2025-03-26]
 

--- a/influxdb3/point_value_iterator.go
+++ b/influxdb3/point_value_iterator.go
@@ -44,7 +44,7 @@ type PointValueIterator struct {
 }
 
 // Return a new PointValueIterator
-func newPointValueIterator(reader *flight.Reader) *PointValueIterator {
+func NewPointValueIterator(reader *flight.Reader) *PointValueIterator {
 	return &PointValueIterator{
 		reader: reader,
 		index:  -1,
@@ -56,7 +56,7 @@ func newPointValueIterator(reader *flight.Reader) *PointValueIterator {
 // Its second return value is iterator.Done if there are no more results.
 // Once Next returns Done in the second parameter, all subsequent calls will return Done.
 //
-//	it := newPointValueIterator(flightReader)
+//	it := NewPointValueIterator(flightReader)
 //	for {
 //		PointValue, err := it.Next()
 //		if err == iterator.Done {

--- a/influxdb3/point_value_iterator_test.go
+++ b/influxdb3/point_value_iterator_test.go
@@ -122,7 +122,7 @@ func TestPointValueIterator(t *testing.T) {
 	assert.NoError(t, err)
 
 	fReader := &flight.Reader{Reader: ipcReader}
-	it := newPointValueIterator(fReader)
+	it := NewPointValueIterator(fReader)
 
 	var resultSet0 []int64
 	var resultSet1 []interface{}
@@ -241,7 +241,7 @@ func TestPointValueIteratorError(t *testing.T) {
 
 	fReader := &flight.Reader{Reader: mockReader}
 
-	it := newPointValueIterator(fReader)
+	it := NewPointValueIterator(fReader)
 
 	values, err := it.Next()
 

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -170,7 +170,7 @@ func (c *Client) query(ctx context.Context, query string, parameters QueryParame
 		return nil, err
 	}
 
-	return newQueryIterator(reader), nil
+	return NewQueryIterator(reader), nil
 }
 
 func (c *Client) queryPointValue(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (*PointValueIterator, error) {
@@ -179,7 +179,7 @@ func (c *Client) queryPointValue(ctx context.Context, query string, parameters Q
 		return nil, err
 	}
 
-	return newPointValueIterator(reader), nil
+	return NewPointValueIterator(reader), nil
 }
 
 func (c *Client) getReader(ctx context.Context, query string, parameters QueryParameters, options *QueryOptions) (*flight.Reader, error) {

--- a/influxdb3/query_iterator.go
+++ b/influxdb3/query_iterator.go
@@ -64,7 +64,7 @@ type QueryIterator struct {
 	done bool
 }
 
-func newQueryIterator(reader *flight.Reader) *QueryIterator {
+func NewQueryIterator(reader *flight.Reader) *QueryIterator {
 	return &QueryIterator{
 		reader:        reader,
 		record:        nil,

--- a/influxdb3/query_iterator_test.go
+++ b/influxdb3/query_iterator_test.go
@@ -53,7 +53,7 @@ func TestQueryIteratorEmptyRecord(t *testing.T) {
 	assert.NoError(t, err)
 
 	fReader := &flight.Reader{Reader: ipcReader}
-	it := newQueryIterator(fReader)
+	it := NewQueryIterator(fReader)
 
 	count := 0
 	for it.Next() {
@@ -76,7 +76,7 @@ func TestQueryIteratorError(t *testing.T) {
 
 	fReader := &flight.Reader{Reader: mockReader}
 
-	testIT := newQueryIterator(fReader)
+	testIT := NewQueryIterator(fReader)
 	assert.False(t, testIT.Next(), "iterator should have no next record")
 	assert.Equal(t, testIT.Err().Error(), errorMessage)
 }


### PR DESCRIPTION
Closes https://github.com/InfluxCommunity/influxdb3-go/issues/145

## Proposed Changes

Export functions `NewQueryIterator` and `NewPointValueIterator` to simplify testing.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
