### PR TITLE
chore: change Batcher slog warnings to level DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.6.0 [unreleased]
 
+### Features
+
+1. [#155](https://github.com/InfluxCommunity/influxdb3-go/pull/155): Batcher warnings when buffer data is not being automatically emitted changed to level `Debug` in slog.
+
 ## 2.5.0 [2025-04-10]
 
 ### Features

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -155,7 +155,7 @@ func (b *Batcher) Add(p ...*influxdb3.Point) {
 		if b.callbackEmit == nil {
 			// no emitter callback
 			if b.CurrentLoadSize() >= (b.capacity - b.size) {
-				slog.Warn(
+				slog.Debug(
 					fmt.Sprintf("Batcher is ready, but no callbackEmit is available.  "+
 						"Batcher load is %d points waiting to be emitted.",
 						b.CurrentLoadSize()),

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -98,26 +98,6 @@ type Batcher struct {
 	sync.Mutex
 }
 
-// SetSize sets the batch size.  Units are Points.
-func (b *Batcher) SetSize(s int) {
-	b.size = s
-}
-
-// SetCapacity sets the initial Capacity of the internal []*influxdb3.Point buffer.
-func (b *Batcher) SetCapacity(c int) {
-	b.capacity = c
-}
-
-// SetReadyCallback sets the callbackReady function.
-func (b *Batcher) SetReadyCallback(f func()) {
-	b.callbackReady = f
-}
-
-// SetEmitCallback sets the callbackEmit function.
-func (b *Batcher) SetEmitCallback(f func([]*influxdb3.Point)) {
-	b.callbackEmit = f
-}
-
 // NewBatcher creates and initializes a new Batcher instance applying the
 // specified options. By default, a batch-size is DefaultBatchSize and the
 // initial capacity is DefaultCapacity.
@@ -137,6 +117,26 @@ func NewBatcher(options ...Option) *Batcher {
 	b.points = make([]*influxdb3.Point, 0, b.capacity)
 
 	return b
+}
+
+// SetSize sets the batch size.  Units are Points.
+func (b *Batcher) SetSize(s int) {
+	b.size = s
+}
+
+// SetCapacity sets the initial Capacity of the internal []*influxdb3.Point buffer.
+func (b *Batcher) SetCapacity(c int) {
+	b.capacity = c
+}
+
+// SetReadyCallback sets the callbackReady function.
+func (b *Batcher) SetReadyCallback(f func()) {
+	b.callbackReady = f
+}
+
+// SetEmitCallback sets the callbackEmit function.
+func (b *Batcher) SetEmitCallback(f func([]*influxdb3.Point)) {
+	b.callbackEmit = f
 }
 
 // Add metric(s) to the batcher and call the given callbacks if any
@@ -174,8 +174,16 @@ func (b *Batcher) Ready() bool {
 	return b.isReady()
 }
 
-func (b *Batcher) isReady() bool {
-	return len(b.points) >= b.size
+// Flush drains all points even if the internal buffer is currently larger than size.
+// It does not call the callbackEmit method
+func (b *Batcher) Flush() []*influxdb3.Point {
+	points := b.points
+	b.points = b.points[:0]
+	return points
+}
+
+func (b *Batcher) CurrentLoadSize() int {
+	return len(b.points)
 }
 
 // Emit returns a new batch of points with the provided batch size or with the
@@ -188,6 +196,10 @@ func (b *Batcher) Emit() []*influxdb3.Point {
 	return b.emitPoints()
 }
 
+func (b *Batcher) isReady() bool {
+	return len(b.points) >= b.size
+}
+
 func (b *Batcher) emitPoints() []*influxdb3.Point {
 	l := min(b.size, len(b.points))
 
@@ -195,16 +207,4 @@ func (b *Batcher) emitPoints() []*influxdb3.Point {
 	b.points = b.points[l:]
 
 	return points
-}
-
-// Flush drains all points even if the internal buffer is currently larger than size.
-// It does not call the callbackEmit method
-func (b *Batcher) Flush() []*influxdb3.Point {
-	points := b.points
-	b.points = b.points[:0]
-	return points
-}
-
-func (b *Batcher) CurrentLoadSize() int {
-	return len(b.points)
 }

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -81,6 +81,25 @@ type LPBatcher struct {
 	sync.Mutex
 }
 
+// NewLPBatcher creates and initializes a new LPBatcher instance
+// applying the supplied options. By default a batch size is DefaultByteBatchSize
+// and the initial capacity is the DefaultBufferCapacity.
+func NewLPBatcher(options ...LPOption) *LPBatcher {
+	lpb := &LPBatcher{
+		size:     DefaultByteBatchSize,
+		capacity: DefaultBufferCapacity,
+	}
+
+	// Apply the options
+	for _, o := range options {
+		o(lpb)
+	}
+
+	// setup internal data
+	lpb.buffer = make([]byte, 0, lpb.capacity)
+	return lpb
+}
+
 // SetSize sets the batch size of the batcher
 func (lpb *LPBatcher) SetSize(s int) {
 	lpb.size = s
@@ -99,25 +118,6 @@ func (lpb *LPBatcher) SetReadyCallback(f func()) {
 // SetEmitBytesCallback sets the callbackByteEmit function
 func (lpb *LPBatcher) SetEmitBytesCallback(f func([]byte)) {
 	lpb.callbackByteEmit = f
-}
-
-// NewLPBatcher creates and initializes a new LPBatcher instance
-// applying the supplied options. By default a batch size is DefaultByteBatchSize
-// and the initial capacity is the DefaultBufferCapacity.
-func NewLPBatcher(options ...LPOption) *LPBatcher {
-	lpb := &LPBatcher{
-		size:     DefaultByteBatchSize,
-		capacity: DefaultBufferCapacity,
-	}
-
-	// Apply the options
-	for _, o := range options {
-		o(lpb)
-	}
-
-	// setup internal data
-	lpb.buffer = make([]byte, 0, lpb.capacity)
-	return lpb
 }
 
 // Add lines to the buffer and call appropriate callbacks when
@@ -161,10 +161,6 @@ func (lpb *LPBatcher) Ready() bool {
 	return lpb.isReady()
 }
 
-func (lpb *LPBatcher) isReady() bool {
-	return len(lpb.buffer) >= lpb.size
-}
-
 // Emit returns a new batch of bytes with upto to the provided batch size
 // depending on when the last newline character in the potential batch is met, or
 // with all the remaining bytes. Please drain the bytes at the end of your
@@ -174,6 +170,22 @@ func (lpb *LPBatcher) Emit() []byte {
 	defer lpb.Unlock()
 
 	return lpb.emitBytes()
+}
+
+// Flush drains all bytes even if buffer currently larger than size
+func (lpb *LPBatcher) Flush() []byte {
+	packet := lpb.buffer
+	lpb.buffer = lpb.buffer[:0]
+	return packet
+}
+
+// CurrentLoadSize returns the current size of the internal buffer
+func (lpb *LPBatcher) CurrentLoadSize() int {
+	return len(lpb.buffer)
+}
+
+func (lpb *LPBatcher) isReady() bool {
+	return len(lpb.buffer) >= lpb.size
 }
 
 func (lpb *LPBatcher) emitBytes() []byte {
@@ -204,16 +216,4 @@ func (lpb *LPBatcher) emitBytes() []byte {
 	lpb.buffer = lpb.buffer[len(packet):]
 
 	return packet
-}
-
-// Flush drains all bytes even if buffer currently larger than size
-func (lpb *LPBatcher) Flush() []byte {
-	packet := lpb.buffer
-	lpb.buffer = lpb.buffer[:0]
-	return packet
-}
-
-// CurrentLoadSize returns the current size of the internal buffer
-func (lpb *LPBatcher) CurrentLoadSize() int {
-	return len(lpb.buffer)
 }

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -142,7 +142,7 @@ func (lpb *LPBatcher) Add(lines ...string) {
 		if lpb.callbackByteEmit == nil {
 			// no emitter callback
 			if lpb.CurrentLoadSize() > (lpb.capacity - lpb.size) {
-				slog.Warn(
+				slog.Debug(
 					fmt.Sprintf("Batcher is ready, but no callbackByteEmit is available.  "+
 						"Batcher load is %d bytes waiting to be emitted.",
 						lpb.CurrentLoadSize()),

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -273,6 +273,13 @@ func NewFromEnv() (*Client, error) {
 	return New(cfg)
 }
 
+// Close closes all idle connections.
+func (c *Client) Close() error {
+	c.config.HTTPClient.CloseIdleConnections()
+	err := c.queryClient.Close()
+	return err
+}
+
 // makeAPICall issues an HTTP request to InfluxDB host API url according to parameters.
 // Additionally, sets Authorization header and User-Agent.
 // It returns http.Response or error. Error can be a *hostError if host responded with error.
@@ -369,11 +376,4 @@ func (c *Client) resolveHTTPError(r *http.Response) error {
 	httpError.Headers = r.Header
 
 	return &httpError.ServerError
-}
-
-// Close closes all idle connections.
-func (c *Client) Close() error {
-	c.config.HTTPClient.CloseIdleConnections()
-	err := c.queryClient.Close()
-	return err
 }

--- a/influxdb3/testutil/mocks.go
+++ b/influxdb3/testutil/mocks.go
@@ -56,21 +56,6 @@ type MockFlightServer struct {
 	flight.BaseFlightServer
 }
 
-func (f *MockFlightServer) writeBlob(fs flight.FlightService_DoGetServer, size int64) error {
-	recs := f.MakeBlobRecords("test", size)
-
-	w := flight.NewRecordWriter(fs, ipc.WithSchema(recs[0].Schema()))
-
-	for _, r := range recs {
-		err := w.Write(r)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (f *MockFlightServer) DoGet(tkt *flight.Ticket, fs flight.FlightService_DoGetServer) error {
 	bt, btErr := BlobTicketFromJSONBytes(tkt.GetTicket())
 	if btErr == nil {
@@ -297,6 +282,21 @@ func (f *MockFlightServer) MakeConstantRecords() []arrow.Record {
 
 	f.Records["constants"] = recs
 	return recs
+}
+
+func (f *MockFlightServer) writeBlob(fs flight.FlightService_DoGetServer, size int64) error {
+	recs := f.MakeBlobRecords("test", size)
+
+	w := flight.NewRecordWriter(fs, ipc.WithSchema(recs[0].Schema()))
+
+	for _, r := range recs {
+		err := w.Write(r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // copied from arrow-go/flight/flight_test.go


### PR DESCRIPTION
Closes #

## Proposed Changes

* Change the slog warnings for Batcher and LPBatcher, when buffer data can't be automatically emitted to DEBUG. 
* Reorder functions for Batcher, LPBatcher, Client and MockFlightServer to satisfy new linter requirements.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
