### PR TITLE
fix: issue157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
    - `SetCapacity` methods on both structures are now deprecated.
    - `WithCapacity` and `WithBufferCapacity` options are now deprecated.
 
-
 ## 2.6.0 [2025-04-15]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 2.7.0 [unreleased]
 
+### Bug Fixes
+
+1. [#158](https://github.com/InfluxCommunity/influxdb3-go/pull/158): Refactor Batcher and LPBatcher:
+   - Fields and methods using `capacity` renamed to `initialCapacity`.
+   - Log messages when buffer data is not being emitted are simplified.
+   - `SetCapacity` methods on both structures are now deprecated.
+   - `WithCapacity` and `WithBufferCapacity` options are now deprecated.
+
+
 ## 2.6.0 [2025-04-15]
 
 ### Features

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -37,7 +37,7 @@ const DefaultBatchSize = 1000
 // DefaultInitialCapacity is the default initial capacity of the point buffer
 const DefaultInitialCapacity = 2 * DefaultBatchSize
 
-//Deprecated: use DefaultInitialCapacity
+// Deprecated: use DefaultInitialCapacity
 const DefaultCapacity = DefaultInitialCapacity
 
 // Emittable provides the base for any type

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -37,6 +37,9 @@ const DefaultBatchSize = 1000
 // DefaultInitialCapacity is the default initial capacity of the point buffer
 const DefaultInitialCapacity = 2 * DefaultBatchSize
 
+//Deprecated: use DefaultInitialCapacity
+const DefaultCapacity = DefaultInitialCapacity
+
 // Emittable provides the base for any type
 // that will collect and then emit data upon
 // reaching a ready state.
@@ -110,7 +113,7 @@ type Batcher struct {
 
 // NewBatcher creates and initializes a new Batcher instance applying the
 // specified options. By default, a batch-size is DefaultBatchSize and the
-// initial capacity is DefaultCapacity.
+// initial capacity is DefaultInitialCapacity.
 func NewBatcher(options ...Option) *Batcher {
 	// Set up a batcher with the default values
 	b := &Batcher{
@@ -171,12 +174,10 @@ func (b *Batcher) Add(p ...*influxdb3.Point) {
 		}
 		if b.callbackEmit == nil {
 			// no emitter callback
-			if b.CurrentLoadSize() >= (b.initialCapacity - b.size) {
-				slog.Debug(
-					fmt.Sprintf("Batcher load is %d points waiting to be emitted.",
-						b.CurrentLoadSize()),
-				)
-			}
+			slog.Debug(
+				fmt.Sprintf("Batcher load is %d points waiting to be emitted.",
+					b.CurrentLoadSize()),
+			)
 			break
 		}
 		b.callbackEmit(b.emitPoints())

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -44,6 +44,7 @@ type Emittable interface {
 	SetSize(s int)               // setsize
 	SetInitialCapacity(c int)    // set capacity
 	SetReadyCallback(rcb func()) // ready Callback
+	SetCapacity(c int)           // Deprecated: use SetInitialCapacity instead
 }
 
 // PointEmittable provides the basis for any type emitting
@@ -74,7 +75,7 @@ func WithInitialCapacity(capacity int) Option {
 // Deprecated: use WithInitialCapacity instead
 func WithCapacity(capacity int) Option {
 	return func(b PointEmittable) {
-		b.SetInitialCapacity(capacity)
+		b.SetCapacity(capacity)
 	}
 }
 

--- a/influxdb3/batching/batcher.go
+++ b/influxdb3/batching/batcher.go
@@ -69,6 +69,15 @@ func WithInitialCapacity(capacity int) Option {
 	}
 }
 
+// WithCapacity changes the initial capacity of the internal buffer
+//
+// Deprecated: use WithInitialCapacity instead
+func WithCapacity(capacity int) Option {
+	return func(b PointEmittable) {
+		b.SetInitialCapacity(capacity)
+	}
+}
+
 // WithReadyCallback sets the function called when a new batch is ready. The
 // batcher will wait for the callback to finish, so please return as fast as
 // possible and move long-running processing to a  go-routine.
@@ -126,6 +135,13 @@ func (b *Batcher) SetSize(s int) {
 
 // SetInitialCapacity sets the initial Capacity of the internal []*influxdb3.Point buffer.
 func (b *Batcher) SetInitialCapacity(c int) {
+	b.initialCapacity = c
+}
+
+// SetCapacity sets the initial Capacity of the internal []*influxdb3.Point buffer.
+//
+// Deprecated: use SetInitialCapacity instead.
+func (b *Batcher) SetCapacity(c int) {
 	b.initialCapacity = c
 }
 

--- a/influxdb3/batching/batcher_test.go
+++ b/influxdb3/batching/batcher_test.go
@@ -36,7 +36,7 @@ func TestDefaultValues(t *testing.T) {
 
 	// Check that default values are set correctly
 	assert.Equal(t, DefaultBatchSize, b.size)
-	assert.Equal(t, DefaultCapacity, cap(b.points))
+	assert.Equal(t, DefaultInitialCapacity, cap(b.points))
 }
 
 func TestCustomValues(t *testing.T) {
@@ -45,7 +45,7 @@ func TestCustomValues(t *testing.T) {
 
 	b := NewBatcher(
 		WithSize(batchSize),
-		WithCapacity(capacity),
+		WithInitialCapacity(capacity),
 	)
 
 	assert.Equal(t, batchSize, b.size)
@@ -167,7 +167,7 @@ func TestAddLargerThanSize(t *testing.T) {
 
 	resultSet := make([]*influxdb3.Point, 0)
 	b := NewBatcher(WithSize(batchSize),
-		WithCapacity(batchSize*3),
+		WithInitialCapacity(batchSize*3),
 		WithEmitCallback(func(points []*influxdb3.Point) {
 			resultSet = append(resultSet, points...)
 			emitCt++
@@ -192,7 +192,7 @@ func TestFlush(t *testing.T) {
 			time.Now())
 	}
 
-	b := NewBatcher(WithSize(batchSize), WithCapacity(batchSize*2))
+	b := NewBatcher(WithSize(batchSize), WithInitialCapacity(batchSize*2))
 	b.Add(pointSet...)
 	assert.Equal(t, batchSize*loadFactor, b.CurrentLoadSize())
 	flushed := b.Flush()

--- a/influxdb3/batching/batcher_test.go
+++ b/influxdb3/batching/batcher_test.go
@@ -52,6 +52,21 @@ func TestCustomValues(t *testing.T) {
 	assert.Equal(t, capacity, cap(b.points))
 }
 
+// Deprecated: verifying deprecated option
+func TestBatcherWithCapacityOption(t *testing.T) {
+	batchSize := 10
+	capacity := 100
+
+	b := NewBatcher(
+		WithSize(batchSize),
+		WithCapacity(capacity),
+	)
+
+	assert.Equal(t, batchSize, b.size)
+	assert.Equal(t, capacity, b.initialCapacity)
+	assert.Equal(t, capacity, cap(b.points))
+}
+
 func TestAddAndCallBackEmit(t *testing.T) {
 	batchSize := 5
 	emitted := false

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -10,6 +10,9 @@ import (
 const DefaultByteBatchSize = 100000
 const DefaultInitialBufferCapacity = DefaultByteBatchSize * 2
 
+//Deprecated: use DefaultInitialBufferCapacity
+const DefaultBufferCapacity = DefaultInitialBufferCapacity
+
 // ByteEmittable provides the basis for a type Emitting line protocol data
 // as a byte array (i.e. []byte).
 type ByteEmittable interface {
@@ -158,12 +161,10 @@ func (lpb *LPBatcher) Add(lines ...string) {
 		}
 		if lpb.callbackByteEmit == nil {
 			// no emitter callback
-			if lpb.CurrentLoadSize() > (lpb.initialCapacity - lpb.size) {
-				slog.Debug(
-					fmt.Sprintf("Batcher load is %d bytes waiting to be emitted.",
-						lpb.CurrentLoadSize()),
-				)
-			}
+			slog.Debug(
+				fmt.Sprintf("Batcher load is %d bytes waiting to be emitted.",
+					lpb.CurrentLoadSize()),
+			)
 			break
 		}
 		lpb.callbackByteEmit(lpb.emitBytes())

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -35,6 +35,16 @@ func WithInitialBufferCapacity(capacity int) LPOption {
 	}
 }
 
+// WithBufferCapacity changes the initial capacity of the internal buffer
+// The unit is byte
+//
+// Deprecated: use WithInitialBufferCapacity instead
+func WithBufferCapacity(capacity int) LPOption {
+	return func(b ByteEmittable) {
+		b.SetInitialCapacity(capacity)
+	}
+}
+
 // WithByteEmitReadyCallback sets the function called when a new batch is ready. The
 // batcher will wait for the callback to finish, so please return as fast as
 // possible and move long-running processing to a  go-routine.
@@ -107,6 +117,13 @@ func (lpb *LPBatcher) SetSize(s int) {
 
 // SetInitialCapacity sets the initial capacity of the internal buffer
 func (lpb *LPBatcher) SetInitialCapacity(c int) {
+	lpb.initialCapacity = c
+}
+
+// SetCapacity sets the initial capacity of the internal buffer
+//
+// Deprecated: use SetInitialCapacity instead
+func (lpb *LPBatcher) SetCapacity(c int) {
 	lpb.initialCapacity = c
 }
 

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -10,7 +10,7 @@ import (
 const DefaultByteBatchSize = 100000
 const DefaultInitialBufferCapacity = DefaultByteBatchSize * 2
 
-//Deprecated: use DefaultInitialBufferCapacity
+// Deprecated: use DefaultInitialBufferCapacity
 const DefaultBufferCapacity = DefaultInitialBufferCapacity
 
 // ByteEmittable provides the basis for a type Emitting line protocol data

--- a/influxdb3/batching/lp_batcher.go
+++ b/influxdb3/batching/lp_batcher.go
@@ -41,7 +41,7 @@ func WithInitialBufferCapacity(capacity int) LPOption {
 // Deprecated: use WithInitialBufferCapacity instead
 func WithBufferCapacity(capacity int) LPOption {
 	return func(b ByteEmittable) {
-		b.SetInitialCapacity(capacity)
+		b.SetCapacity(capacity)
 	}
 }
 

--- a/influxdb3/batching/lp_batcher_test.go
+++ b/influxdb3/batching/lp_batcher_test.go
@@ -29,6 +29,7 @@ func TestLPCustomValues(t *testing.T) {
 
 	assert.Equal(t, size, lpb.size)
 	assert.Equal(t, capacity, lpb.initialCapacity)
+	assert.Equal(t, capacity, cap(lpb.buffer))
 	assert.Nil(t, lpb.callbackReady)
 	assert.Nil(t, lpb.callbackByteEmit)
 }
@@ -90,6 +91,21 @@ func TestEmitEmptyBatcher(t *testing.T) {
 
 	results := lpb.Emit()
 
+	assert.Empty(t, results)
+}
+
+// Deprecated: verifying deprecated option
+func TestLPBatcherWithBufferCapacity(t *testing.T) {
+	size := 256
+	capacity := size * 2
+
+	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+
+	assert.Equal(t, size, lpb.size)
+	assert.Equal(t, capacity, lpb.initialCapacity)
+	assert.Equal(t, capacity, cap(lpb.buffer))
+
+	results := lpb.Emit()
 	assert.Empty(t, results)
 }
 

--- a/influxdb3/batching/lp_batcher_test.go
+++ b/influxdb3/batching/lp_batcher_test.go
@@ -13,7 +13,7 @@ func TestLPDefaultValues(t *testing.T) {
 	lpb := NewLPBatcher()
 
 	assert.Equal(t, DefaultByteBatchSize, lpb.size)
-	assert.Equal(t, DefaultBufferCapacity, lpb.capacity)
+	assert.Equal(t, DefaultInitialBufferCapacity, lpb.initialCapacity)
 	assert.Nil(t, lpb.callbackReady)
 	assert.Nil(t, lpb.callbackByteEmit)
 }
@@ -24,11 +24,11 @@ func TestLPCustomValues(t *testing.T) {
 
 	lpb := NewLPBatcher(
 		WithBufferSize(size),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 	)
 
 	assert.Equal(t, size, lpb.size)
-	assert.Equal(t, capacity, lpb.capacity)
+	assert.Equal(t, capacity, lpb.initialCapacity)
 	assert.Nil(t, lpb.callbackReady)
 	assert.Nil(t, lpb.callbackByteEmit)
 }
@@ -42,7 +42,7 @@ func TestLPBatcherCreate(t *testing.T) {
 
 	l := NewLPBatcher(
 		WithBufferSize(size),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithEmitBytesCallback(func(ba []byte) {
 			emitted = true
 			emittedBytes = ba
@@ -50,7 +50,7 @@ func TestLPBatcherCreate(t *testing.T) {
 	)
 
 	assert.Equal(t, size, l.size)
-	assert.Equal(t, capacity, l.capacity)
+	assert.Equal(t, capacity, l.initialCapacity)
 	assert.False(t, emitted)
 	assert.Nil(t, emittedBytes)
 	assert.NotNil(t, l.callbackByteEmit)
@@ -60,7 +60,7 @@ func TestLPBatcherCreate(t *testing.T) {
 func TestLPReady(t *testing.T) {
 	size := 10
 	capacity := size * 2
-	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+	lpb := NewLPBatcher(WithBufferSize(size), WithInitialBufferCapacity(capacity))
 	lpb.Add("0123456789ABCDEF")
 
 	assert.True(t, lpb.Ready(), "LPBatcher should be ready when the batch size is reached")
@@ -72,7 +72,7 @@ func TestLPReadyCallback(t *testing.T) {
 	readyCalled := false
 
 	lpb := NewLPBatcher(WithBufferSize(size),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithByteEmitReadyCallback(func() {
 			readyCalled = true
 		}))
@@ -86,7 +86,7 @@ func TestEmitEmptyBatcher(t *testing.T) {
 	size := 256
 	capacity := size * 2
 
-	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+	lpb := NewLPBatcher(WithBufferSize(size), WithInitialBufferCapacity(capacity))
 
 	results := lpb.Emit()
 
@@ -97,7 +97,7 @@ func TestAddLineAppendsLF(t *testing.T) {
 	size := 256
 	capacity := size * 2
 
-	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+	lpb := NewLPBatcher(WithBufferSize(size), WithInitialBufferCapacity(capacity))
 	lines := []string{
 		"cpu,location=roswell,id=R2D2 fVal=3.14,iVal=42i",
 		"cpu,location=dyatlov,id=C3PO fVal=2.71,iVal=21i",
@@ -111,7 +111,7 @@ func TestAddLineAppendsLF(t *testing.T) {
 func TestAddLineAppendsNoLFWhenPresent(t *testing.T) {
 	size := 256
 	capacity := size * 2
-	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+	lpb := NewLPBatcher(WithBufferSize(size), WithInitialBufferCapacity(capacity))
 	lines := []string{
 		"cpu,location=roswell,id=R2D2 fVal=3.14,iVal=42i\n",
 		"cpu,location=dyatlov,id=C3PO fVal=2.71,iVal=21i\n",
@@ -141,7 +141,7 @@ func TestLPAddAndPartialEmit(t *testing.T) {
 
 	lpb := NewLPBatcher(
 		WithBufferSize(size),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithEmitBytesCallback(func(ba []byte) {
 			emitCount++
 			emittedBytes = append(emittedBytes, ba...)
@@ -169,7 +169,7 @@ func TestLPAddAndEmitCallBack(t *testing.T) {
 
 	lpb := NewLPBatcher(
 		WithBufferSize(batchSize),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithByteEmitReadyCallback(func() {
 			readyCalled++
 		}),
@@ -208,7 +208,7 @@ func TestLPBufferFlush(t *testing.T) {
 	size := 10
 	capacity := size * 2
 
-	lpb := NewLPBatcher(WithBufferSize(size), WithBufferCapacity(capacity))
+	lpb := NewLPBatcher(WithBufferSize(size), WithInitialBufferCapacity(capacity))
 	testString := "0123456789ABCDEF\n"
 
 	assert.Equal(t, 0, lpb.CurrentLoadSize())
@@ -227,7 +227,7 @@ func TestLPThreadSafety(t *testing.T) {
 	testString := "123456789ABCDEF\n"
 
 	lpb := NewLPBatcher(WithBufferSize(size),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithEmitBytesCallback(func(ba []byte) {
 			emitCt++
 		}))
@@ -265,7 +265,7 @@ func TestLPAddLargerThanSize(t *testing.T) {
 	resultBuffer := make([]byte, 0)
 	lpb := NewLPBatcher(
 		WithBufferSize(batchSize),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithEmitBytesCallback(func(ba []byte) {
 			emitCt++
 			resultBuffer = append(resultBuffer, ba...)
@@ -299,7 +299,7 @@ func TestLPAddLinesLargerThanSize(t *testing.T) {
 	resultBuffer := make([]byte, 0)
 	lpb := NewLPBatcher(
 		WithBufferSize(batchSize),
-		WithBufferCapacity(capacity),
+		WithInitialBufferCapacity(capacity),
 		WithEmitBytesCallback(func(ba []byte) {
 			emitCt++
 			resultBuffer = append(resultBuffer, ba...)

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -633,7 +633,7 @@ func TestLPBatcher(t *testing.T) {
 	lag := 0
 	lpb := batching.NewLPBatcher(
 		batching.WithBufferSize(size),
-		batching.WithBufferCapacity(capacity),
+		batching.WithInitialBufferCapacity(capacity),
 		batching.WithByteEmitReadyCallback(func() {
 			readyCt++
 		}),


### PR DESCRIPTION
Closes #157

## Proposed Changes

* Simplify debug messages when batcher buffer data is not being emitted.
* Rename Batcher methods and fields from `xCapacity` to `xInitialCapacity`
* Mark Batcher methods using `xCapacity` as deprecated

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
