### PR TITLE
feat: fast no-sync write support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## 2.8.0 [unreleased]
 
+### Features
+
+1. [#159](https://github.com/InfluxCommunity/influxdb3-go/pull/159): Support fast writes without waiting for WAL
+   persistence:
+   - New write option (`WriteOptions.NoSync`) added: `true` value means faster write but without the confirmation that
+     the data was persisted. Default value: `false`.
+   - **Supported by self-managed InfluxDB 3 Core and Enterprise servers only!**
+   - Also configurable via connection string query parameter (`writeNoSync`).
+   - Also configurable via environment variable (`INFLUX_WRITE_NO_SYNC`).
+   - Long precision string values added from v3 HTTP API: `"nanosecond"`, `"microsecond"`, `"millisecond"`, `"second"` (
+     in addition to the existing `"ns"`, `"us"`, `"ms"`, `"s"`).
+
 ## 2.7.0 [2025-05-15]
 
 ### Bug Fixes

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -91,7 +91,7 @@ func New(config ClientConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing host URL: %w", err)
 	}
-	c.apiURL.Path = path.Join(c.apiURL.Path, "api/v2") + "/"
+	c.apiURL.Path = path.Join(c.apiURL.Path, "api") + "/"
 
 	// Prepare authorization header value
 	authScheme := c.config.AuthScheme
@@ -246,6 +246,8 @@ func setHTTPClientCertPool(httpClient *http.Client, certPool *x509.CertPool, con
 //   - database - database (bucket) name
 //   - precision - timestamp precision when writing data
 //   - gzipThreshold - payload size threshold for gzipping data
+//   - writeNoSync - bool value whether to skip waiting for WAL persistence on write.
+//     (See WriteOptions.NoSync for more details)
 func NewFromConnectionString(connectionString string) (*Client, error) {
 	cfg := ClientConfig{}
 	err := cfg.parse(connectionString)
@@ -264,6 +266,8 @@ func NewFromConnectionString(connectionString string) (*Client, error) {
 //   - INFLUX_DATABASE - database (bucket) name
 //   - INFLUX_PRECISION - timestamp precision when writing data
 //   - INFLUX_GZIP_THRESHOLD - payload size threshold for gzipping data
+//   - INFLUX_WRITE_NO_SYNC - bool value whether to skip waiting for WAL persistence on write
+//     (See WriteOptions.NoSync for more details)
 func NewFromEnv() (*Client, error) {
 	cfg := ClientConfig{}
 	err := cfg.env()

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -394,7 +394,7 @@ func TestNewFromConnectionString(t *testing.T) {
 			},
 		},
 		{
-			name: "with precision long value",
+			name: "with precision long value - second",
 			cs:   "https://host:8086?token=abc&org=my-org&database=my-db&precision=second",
 			cfg: &ClientConfig{
 				Host:         "https://host:8086",
@@ -404,6 +404,20 @@ func TestNewFromConnectionString(t *testing.T) {
 				WriteOptions: &WriteOptions{
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					Precision:     lineprotocol.Second,
+				},
+			},
+		},
+		{
+			name: "with precision long value - microsecond",
+			cs:   "https://host:8086?token=abc&org=my-org&database=my-db&precision=microsecond",
+			cfg: &ClientConfig{
+				Host:         "https://host:8086",
+				Token:        "abc",
+				Organization: "my-org",
+				Database:     "my-db",
+				WriteOptions: &WriteOptions{
+					GzipThreshold: DefaultWriteOptions.GzipThreshold,
+					Precision:     lineprotocol.Microsecond,
 				},
 			},
 		},

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -395,7 +395,7 @@ func TestNewFromConnectionString(t *testing.T) {
 		},
 		{
 			name: "with precision long value",
-			cs:   "https://host:8086?token=abc&org=my-org&database=my-db&precision=microsecond",
+			cs:   "https://host:8086?token=abc&org=my-org&database=my-db&precision=second",
 			cfg: &ClientConfig{
 				Host:         "https://host:8086",
 				Token:        "abc",
@@ -403,7 +403,7 @@ func TestNewFromConnectionString(t *testing.T) {
 				Database:     "my-db",
 				WriteOptions: &WriteOptions{
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
-					Precision:     lineprotocol.Microsecond,
+					Precision:     lineprotocol.Second,
 				},
 			},
 		},
@@ -533,7 +533,7 @@ func TestNewFromEnv(t *testing.T) {
 				"INFLUX_TOKEN":     "abc",
 				"INFLUX_ORG":       "my-org",
 				"INFLUX_DATABASE":  "my-db",
-				"INFLUX_PRECISION": "microsecond",
+				"INFLUX_PRECISION": "nanosecond",
 			},
 			cfg: &ClientConfig{
 				Host:         "http://host:8086",
@@ -541,7 +541,7 @@ func TestNewFromEnv(t *testing.T) {
 				Organization: "my-org",
 				Database:     "my-db",
 				WriteOptions: &WriteOptions{
-					Precision:     lineprotocol.Microsecond,
+					Precision:     lineprotocol.Nanosecond,
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					NoSync:        DefaultWriteOptions.NoSync,
 				},

--- a/influxdb3/management_serverless.go
+++ b/influxdb3/management_serverless.go
@@ -70,7 +70,7 @@ func (c *ServerlessClient) CreateBucket(ctx context.Context, bucket *Bucket) err
 		bucket.Name = c.client.config.Database
 	}
 
-	return c.createBucket(ctx, "/api/v2/buckets", bucket)
+	return c.createBucket(ctx, "v2/buckets", bucket)
 }
 
 // createBucket is a helper function for CreateBucket to enhance test coverage.

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -58,6 +58,16 @@ type WriteOptions struct {
 
 	// Write body larger than the threshold is gzipped. 0 for no compression.
 	GzipThreshold int
+
+	// Instructs the server whether to wait with the response until WAL persistence completes.
+	// NoSync=true means faster write but without the confirmation that the data was persisted.
+	//
+	// Note: This option is supported by InfluxDB 3 Core and Enterprise servers only.
+	// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Clould Serverless/Dedicated)
+	// the write operation will fail with an error.
+	//
+	// Default value: false.
+	NoSync bool
 }
 
 // DefaultQueryOptions specifies default query options
@@ -69,6 +79,7 @@ var DefaultQueryOptions = QueryOptions{
 var DefaultWriteOptions = WriteOptions{
 	Precision:     lineprotocol.Nanosecond,
 	GzipThreshold: 1_000,
+	NoSync:        false,
 }
 
 // Option is a functional option type that can be passed to Client.Query and Client.Write methods.
@@ -88,6 +99,7 @@ type QueryOption = Option
 //   - WithPrecision
 //   - WithGzipThreshold
 //   - WithDefaultTags
+//   - WithNoSync
 type WriteOption = Option
 
 // WithDatabase is used to override default database in Client.Query and Client.Write methods.
@@ -133,6 +145,13 @@ func WithGzipThreshold(gzipThreshold int) Option {
 func WithDefaultTags(tags map[string]string) Option {
 	return func(o *options) {
 		o.DefaultTags = tags
+	}
+}
+
+// WithNoSync is used to override default tags in Client.Write methods.
+func WithNoSync(noSync bool) Option {
+	return func(o *options) {
+		o.NoSync = noSync
 	}
 }
 

--- a/influxdb3/options_test.go
+++ b/influxdb3/options_test.go
@@ -122,6 +122,7 @@ func TestWriteOptions(t *testing.T) {
 				Database:      "db-x",
 				Precision:     DefaultWriteOptions.Precision,
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
+				NoSync:        DefaultWriteOptions.NoSync,
 			},
 		},
 		{
@@ -131,19 +132,22 @@ func TestWriteOptions(t *testing.T) {
 				Database:      "db-x",
 				Precision:     lineprotocol.Millisecond,
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
+				NoSync:        DefaultWriteOptions.NoSync,
 			},
 		},
 		{
-			name: "override database and precision and GZIP threshold",
+			name: "override database, precision, GZIP threshold, write no sync",
 			opts: va(
 				WithDatabase("db-x"),
 				WithPrecision(lineprotocol.Millisecond),
 				WithGzipThreshold(4096),
+				WithNoSync(true),
 			),
 			want: &WriteOptions{
 				Database:      "db-x",
 				Precision:     lineprotocol.Millisecond,
 				GzipThreshold: 4096,
+				NoSync:        true,
 			},
 		},
 	}

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -220,7 +220,8 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 	resp, err := c.makeAPICall(ctx, *params)
 	if err != nil {
 		var svErr *ServerError
-		if options.NoSync && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed && strings.HasSuffix(params.endpointURL.Path, "/api/v3/write_lp") {
+		if options.NoSync && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed &&
+			strings.HasSuffix(params.endpointURL.Path, "/api/v3/write_lp") {
 			// Server does not support the v3 write API, can't use the NoSync option.
 			return errors.New("server doesn't support write with NoSync=true (supported by InfluxDB 3 Core/Enterprise servers only)")
 		}

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -33,7 +33,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -1151,5 +1151,4 @@ func TestToV3PrecisionString(t *testing.T) {
 	assert.Panics(t, func() {
 		toV3PrecisionString(5)
 	})
-
 }

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -31,7 +31,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -366,6 +368,7 @@ func TestWriteCorrectUrl(t *testing.T) {
 	defer ts.Close()
 	options := DefaultWriteOptions
 	options.Precision = lineprotocol.Millisecond
+	options.NoSync = false
 	c, err := New(ClientConfig{
 		Host:         ts.URL + "/path/",
 		Token:        "my-token",
@@ -376,9 +379,117 @@ func TestWriteCorrectUrl(t *testing.T) {
 	require.NoError(t, err)
 	err = c.Write(context.Background(), []byte("a f=1"))
 	assert.NoError(t, err)
-	correctPath = "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms"
 	err = c.Write(context.Background(), []byte("a f=1"))
 	assert.NoError(t, err)
+}
+
+func TestWriteCorrectUrlNoSync(t *testing.T) {
+	var correctPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// initialization of query client
+		if r.Method == "PRI" {
+			return
+		}
+		assert.EqualValues(t, correctPath, r.URL.String())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	options := DefaultWriteOptions
+	options.Precision = lineprotocol.Millisecond
+
+	clientConfig := ClientConfig{
+		Host:         ts.URL + "/path/",
+		Token:        "my-token",
+		Organization: "my-org",
+		Database:     "my-database",
+		WriteOptions: &options,
+	}
+
+	// options.NoSync unset
+	c, err := New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms" // v2 call
+	err = c.Write(context.Background(), []byte("a f=1"))
+	assert.NoError(t, err)
+
+	// options.NoSync = false
+	options.NoSync = false
+	c, err = New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms" // v2 call
+	err = c.Write(context.Background(), []byte("a f=1"))
+	assert.NoError(t, err)
+
+	// options.NoSync = true
+	options.NoSync = true
+	c, err = New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond" // v3 call
+	err = c.Write(context.Background(), []byte("a f=1"))
+	assert.NoError(t, err)
+
+	// options.NoSync = false & WithNoSync(true)
+	options.NoSync = false
+	c, err = New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond" // v3 call
+	err = c.Write(context.Background(), []byte("a f=1"), WithNoSync(true))
+	assert.NoError(t, err)
+
+	// options.NoSync = true & WithNoSync(false)
+	options.NoSync = true
+	c, err = New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms" // v2 call
+	err = c.Write(context.Background(), []byte("a f=1"), WithNoSync(false))
+	assert.NoError(t, err)
+}
+
+func TestWriteWithNoSyncToV2Server(t *testing.T) {
+	var correctPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// initialization of query client
+		if r.Method == "PRI" {
+			return
+		}
+		// Fails on v3 API calls.
+		if strings.Contains(r.URL.Path, "/api/v3/") {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+		assert.EqualValues(t, correctPath, r.URL.String())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	options := DefaultWriteOptions
+	options.Precision = lineprotocol.Millisecond
+
+	clientConfig := ClientConfig{
+		Host:         ts.URL + "/path/",
+		Token:        "my-token",
+		Organization: "my-org",
+		Database:     "my-database",
+		WriteOptions: &options,
+	}
+
+	// options.NoSync = false
+	options.NoSync = false
+	c, err := New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms" // v2 call
+	err = c.Write(context.Background(), []byte("a f=1"))
+	assert.NoError(t, err)
+
+	// options.NoSync = true
+	options.NoSync = true
+	c, err = New(clientConfig)
+	require.NoError(t, err)
+	correctPath = "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond" // v3 call
+	err = c.Write(context.Background(), []byte("a f=1"))
+	// should fail, as v3 API is not supported
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "server doesn't support write with NoSync=true (supported by InfluxDB 3 Core/Enterprise servers only)")
 }
 
 func TestWritePointsAndBytes(t *testing.T) {

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -1142,3 +1142,14 @@ func TestWriteWithMaxIdleConnections(t *testing.T) {
 	assert.Equal(t, batch1Count+batch2Count-maxIdleConnections, uniqueConnectionCount)
 	assert.Equal(t, batch1Count+batch2Count, requestCount)
 }
+
+func TestToV3PrecisionString(t *testing.T) {
+	assert.Equal(t, "nanosecond", toV3PrecisionString(lineprotocol.Nanosecond))
+	assert.Equal(t, "microsecond", toV3PrecisionString(lineprotocol.Microsecond))
+	assert.Equal(t, "millisecond", toV3PrecisionString(lineprotocol.Millisecond))
+	assert.Equal(t, "second", toV3PrecisionString(lineprotocol.Second))
+	assert.Panics(t, func() {
+		toV3PrecisionString(5)
+	})
+
+}


### PR DESCRIPTION
## Proposed Changes

Support fast writes without waiting for WAL persistence:
   - New write option (`WriteOptions.NoSync`) added: `true` value means faster write but without the confirmation that
     the data was persisted. Default value: `false`.
   - **Supported by self-managed InfluxDB 3 Core and Enterprise servers only!**
   - Also configurable via connection string query parameter (`writeNoSync`).
   - Also configurable via environment variable (`INFLUX_WRITE_NO_SYNC`).
   - Long precision string values added from v3 HTTP API: `"nanosecond"`, `"microsecond"`, `"millisecond"`, `"second"` (in addition to the existing `"ns"`, `"us"`, `"ms"`, `"s"`).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
