### PR TITLE
feat: convert named type

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+#Revaluate if some new checking rules worth follow?
 version: "2"
 output:
   formats:
@@ -13,6 +14,7 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
+    - embeddedstructfieldcheck
     - forcetypeassert
     - funlen
     - gochecknoglobals
@@ -20,6 +22,7 @@ linters:
     - mnd
     - nilnil
     - nlreturn
+    - noinlineerr
     - staticcheck
     - tagliatelle
     - testifylint
@@ -27,6 +30,8 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+    - wsl_v5
+    - revive
   settings:
     gosec:
       excludes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 2.9.0 [unreleased]
 
 ### Features
-
-1. [#171](https://github.com/InfluxCommunity/influxdb3-go/pull/171): Add function to get InfluxDB version.
+ 
+1. [#169](https://github.com/InfluxCommunity/influxdb3-go/pull/169): Support user-defined type converter function for writes points.
+2. [#171](https://github.com/InfluxCommunity/influxdb3-go/pull/171): Add function to get InfluxDB version.
 
 ## 2.8.0 [2025-06-18]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.9.0 [unreleased]
 
 ### Features
- 
+
 1. [#169](https://github.com/InfluxCommunity/influxdb3-go/pull/169): Support user-defined type converter function for writes points.
 2. [#171](https://github.com/InfluxCommunity/influxdb3-go/pull/171): Add function to get InfluxDB version.
 

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -36,8 +36,8 @@ import (
 type Point struct {
 	Values *PointValues
 
-	// fieldConverter this converter function must return one of these types supported by InfluxDB int64, uint64, float64, bool, string.
-	fieldConverter *func(interface{}) interface{}
+	// fieldConverter this converter function must return one of these types supported by InfluxDB int64, uint64, float64, bool, string, []byte.
+	fieldConverter func(interface{}) interface{}
 }
 
 // NewPointWithPointValues returns a new Point with given PointValues.
@@ -294,16 +294,12 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 		fieldKeys = append(fieldKeys, k)
 	}
 	sort.Strings(fieldKeys)
+	converter := p.fieldConverter
+	if converter == nil {
+		converter = convertField
+	}
 	for _, fieldKey := range fieldKeys {
-		fieldValue := p.Values.Fields[fieldKey]
-		if p.fieldConverter != nil {
-			fieldValue = (*p.fieldConverter)(fieldValue)
-			if _, err := isSupportedType(fieldValue); err != nil {
-				return nil, fmt.Errorf("unsupported type: %T", fieldValue)
-			}
-		} else {
-			fieldValue = convertField(fieldValue)
-		}
+		fieldValue := converter(p.Values.Fields[fieldKey])
 		value, ok := lineprotocol.NewValue(fieldValue)
 		if !ok {
 			return nil, fmt.Errorf("invalid value for field %s: %v", fieldKey, fieldValue)
@@ -319,18 +315,8 @@ func (p *Point) MarshalBinaryWithDefaultTags(precision lineprotocol.Precision, d
 }
 
 // WithFieldConverter sets a custom field converter function for transforming field values when used.
-func (p *Point) WithFieldConverter(converter *func(interface{}) interface{}) {
+func (p *Point) WithFieldConverter(converter func(interface{}) interface{}) {
 	p.fieldConverter = converter
-}
-
-// isSupportedType checks if the input value is of a supported type (int64, uint64, float64, bool, string, or []byte).
-// Returns true if the type is supported, otherwise returns false along with an error indicating the unsupported type.
-func isSupportedType(v interface{}) (bool, error) {
-	switch v.(type) {
-	case int64, uint64, float64, bool, string, []byte:
-		return true, nil
-	}
-	return false, fmt.Errorf("unsupported type: %T", v)
 }
 
 // convertField converts any primitive type to types supported by line protocol

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -34,7 +34,9 @@ import (
 
 // Point represents InfluxDB time series point, holding tags and fields
 type Point struct {
-	Values         *PointValues
+	Values *PointValues
+
+	// fieldConverter this converter function must return one of these types supported by InfluxDB int64, uint64, float64, bool, string.
 	fieldConverter *func(interface{}) interface{}
 }
 

--- a/influxdb3/point_test.go
+++ b/influxdb3/point_test.go
@@ -328,7 +328,7 @@ func TestFieldConverterValid(t *testing.T) {
 		}
 		return v
 	}
-	point := createPointWithNamedType(&validConverterFunc)
+	point := createPointWithNamedType(validConverterFunc)
 
 	binary, err := point.MarshalBinary(lineprotocol.Nanosecond)
 	assert.NoError(t, err)
@@ -342,14 +342,14 @@ func TestFieldConverterValid(t *testing.T) {
 
 func TestFieldConverterInvalid(t *testing.T) {
 	invalidConverterFunc := func(v interface{}) interface{} { return v }
-	point := createPointWithNamedType(&invalidConverterFunc)
+	point := createPointWithNamedType(invalidConverterFunc)
 
 	binary, err := point.MarshalBinary(lineprotocol.Nanosecond)
-	assert.Contains(t, err.Error(), "unsupported type:")
+	assert.Contains(t, err.Error(), "invalid value for field")
 	assert.Nil(t, binary)
 }
 
-func createPointWithNamedType(converter *func(interface{}) interface{}) *Point {
+func createPointWithNamedType(converter func(interface{}) interface{}) *Point {
 	point := NewPointWithMeasurement("measurement")
 	point.WithFieldConverter(converter)
 


### PR DESCRIPTION
Closes [#160 ](https://github.com/InfluxCommunity/influxdb3-go/issues/160)

## Proposed Changes

- Support type conversion for named type. Currently named types will be converted to a string.
- I can't find any alternative way, so I have to use reflection api even though it's slow.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
