### PR TITLE
feat: disable linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-#Revaluate if some new checking rules worth follow?
 version: "2"
 output:
   formats:


### PR DESCRIPTION
Closes [#864](https://github.com/influxdata/edge/issues/864)

## Proposed Changes

- I have checked in here [Link](https://golangci-lint.run/usage/linters/#disabled-by-default) and these new linter rules are disabled by default so I think we just following the same.
- The disable has been done in another PR so this PR is just for remove the comment in the .golangci.yml file

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
