### PR TITLE
feat: add comment for getMeasurement function

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - nilnil
     - nlreturn
     - noinlineerr
+    - noctx
     - staticcheck
     - tagliatelle
     - testifylint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 1. [#169](https://github.com/InfluxCommunity/influxdb3-go/pull/169): Support user-defined type converter function for writes points.
 2. [#171](https://github.com/InfluxCommunity/influxdb3-go/pull/171): Add function to get InfluxDB version.
+3. [#176](https://github.com/InfluxCommunity/influxdb3-go/pull/176): Add comment warning null when calling getMeasurement function.
 
 ## 2.8.0 [2025-06-18]
 

--- a/influxdb3/point.go
+++ b/influxdb3/point.go
@@ -84,7 +84,8 @@ func FromValues(values *PointValues) (*Point, error) {
 	return NewPointWithPointValues(values), nil
 }
 
-// GetMeasurement returns the measurement name
+// GetMeasurement returns the measurement name.
+// It will return null when querying with SQL Query.
 func (p *Point) GetMeasurement() string {
 	return p.Values.GetMeasurement()
 }

--- a/influxdb3/point_values.go
+++ b/influxdb3/point_values.go
@@ -46,6 +46,7 @@ func NewPointValues(measurementName string) *PointValues {
 }
 
 // GetMeasurement returns the measurement name
+// It will return null when querying with SQL Query.
 func (pv *PointValues) GetMeasurement() string {
 	return pv.MeasurementName
 }


### PR DESCRIPTION
Closes #

## Proposed Changes

- Add comments to warn user that getMeasurement() function will return null when querying with SQL Query.
- Reference [Link](https://github.com/influxdata/influxdb/issues/26603).
- Disable linter for `noctx` rule base on default rules [Default rules](https://golangci-lint.run/usage/linters/#:~:text=v1.30.0-,noctx%C2%A0Detects%20function%20and%20method%20with%20missing%20usage%20of%20context.Context.,-v1.28.0)
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
