### PR TITLE
feat: clearer timeout parameters

### DIFF
--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -268,6 +268,8 @@ func NewFromConnectionString(connectionString string) (*Client, error) {
 //   - INFLUX_GZIP_THRESHOLD - payload size threshold for gzipping data
 //   - INFLUX_WRITE_NO_SYNC - bool value whether to skip waiting for WAL persistence on write
 //     (See WriteOptions.NoSync for more details)
+//   - INFLUX_WRITE_TIMEOUT - duration value (e.g. 10s) to determine how long to wait for a write response
+//   - INFLUX_QUERY_TIMEOUT - duration value (e.g. 10s) applied to queries for calculating a context response Deadline
 func NewFromEnv() (*Client, error) {
 	cfg := ClientConfig{}
 	err := cfg.env()

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -592,6 +592,64 @@ func TestNewFromEnv(t *testing.T) {
 			},
 			err: "invalid syntax",
 		},
+		{
+			name: "with WriteTimeout env",
+			vars: map[string]string{
+				"INFLUX_HOST":          "http://host:8086",
+				"INFLUX_TOKEN":         "abc",
+				"INFLUX_DATABASE":      "my-db",
+				"INFLUX_ORG":           "my-org",
+				"INFLUX_WRITE_TIMEOUT": "10s",
+			},
+			cfg: &ClientConfig{
+				Host:         "http://host:8086",
+				Token:        "abc",
+				Database:     "my-db",
+				Organization: "my-org",
+				WriteTimeout: 10 * time.Second,
+				WriteOptions: &DefaultWriteOptions,
+			},
+		},
+		{
+			name: "with WriteTimeout env invalid",
+			vars: map[string]string{
+				"INFLUX_HOST":          "http://host:8086",
+				"INFLUX_TOKEN":         "abc",
+				"INFLUX_DATABASE":      "my-db",
+				"INFLUX_ORG":           "my-org",
+				"INFLUX_WRITE_TIMEOUT": "one minute",
+			},
+			err: "time: invalid duration \"one minute\"",
+		},
+		{
+			name: "with QueryTimeout env",
+			vars: map[string]string{
+				"INFLUX_HOST":          "http://host:8086",
+				"INFLUX_TOKEN":         "abc",
+				"INFLUX_DATABASE":      "my-db",
+				"INFLUX_ORG":           "my-org",
+				"INFLUX_QUERY_TIMEOUT": "30s",
+			},
+			cfg: &ClientConfig{
+				Host:         "http://host:8086",
+				Token:        "abc",
+				Database:     "my-db",
+				Organization: "my-org",
+				WriteTimeout: 30 * time.Second,
+				WriteOptions: &DefaultWriteOptions,
+			},
+		},
+		{
+			name: "with QueryTimeout env invalid",
+			vars: map[string]string{
+				"INFLUX_HOST":          "http://host:8086",
+				"INFLUX_TOKEN":         "abc",
+				"INFLUX_DATABASE":      "my-db",
+				"INFLUX_ORG":           "my-org",
+				"INFLUX_WRITE_TIMEOUT": "half minute",
+			},
+			err: "time: invalid duration \"half minute\"",
+		},
 	}
 	clearEnv := func() {
 		os.Unsetenv(envInfluxHost)
@@ -602,6 +660,8 @@ func TestNewFromEnv(t *testing.T) {
 		os.Unsetenv(envInfluxPrecision)
 		os.Unsetenv(envInfluxGzipThreshold)
 		os.Unsetenv(envInfluxWriteNoSync)
+		os.Unsetenv(envInfluxWriteTimeout)
+		os.Unsetenv(envInfluxQueryTimeout)
 	}
 	setEnv := func(vars map[string]string) {
 		for k, v := range vars {

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -43,6 +43,8 @@ const (
 	envInfluxPrecision     = "INFLUX_PRECISION"
 	envInfluxGzipThreshold = "INFLUX_GZIP_THRESHOLD"
 	envInfluxWriteNoSync   = "INFLUX_WRITE_NO_SYNC"
+	envInfluxWriteTimeout  = "INFLUX_WRITE_TIMEOUT"
+	envInfluxQueryTimeout  = "INFLUX_QUERY_TIMEOUT"
 )
 
 const (
@@ -236,6 +238,20 @@ func (c *ClientConfig) env() error {
 		if err := c.parseWriteNoSync(writeNoSync); err != nil {
 			return err
 		}
+	}
+	if writeTimeout, ok := os.LookupEnv(envInfluxWriteTimeout); ok {
+		to, err := time.ParseDuration(writeTimeout)
+		if err != nil {
+			return err
+		}
+		c.WriteTimeout = to
+	}
+	if queryTimeout, ok := os.LookupEnv(envInfluxQueryTimeout); ok {
+		to, err := time.ParseDuration(queryTimeout)
+		if err != nil {
+			return err
+		}
+		c.QueryTimeout = to
 	}
 
 	return nil

--- a/influxdb3/example_test.go
+++ b/influxdb3/example_test.go
@@ -35,9 +35,10 @@ func ExampleNew() {
 		SSLRootsFilePath: "/path/to/certificates.pem",
 		Proxy:            "http://localhost:8888",
 		// Connection parameters:
-		Timeout:               10 * time.Second,
+		WriteTimeout:          10 * time.Second,
 		IdleConnectionTimeout: 90 * time.Second,
 		MaxIdleConnections:    10,
+		QueryTimeout:          2 * time.Minute,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/influxdb3/query.go
+++ b/influxdb3/query.go
@@ -233,7 +233,17 @@ func (c *Client) getReader(ctx context.Context, query string, parameters QueryPa
 		grpcCallOptions = append(grpcCallOptions, options.GrpcCallOptions...)
 	}
 
-	stream, err := c.queryClient.DoGet(ctx, ticket, grpcCallOptions...)
+	var _ctx context.Context
+
+	if c.config.QueryTimeout > 0 {
+		var cancel context.CancelFunc
+		_ctx, cancel = context.WithTimeout(ctx, c.config.QueryTimeout)
+		defer cancel()
+	} else {
+		_ctx = ctx
+	}
+
+	stream, err := c.queryClient.DoGet(_ctx, ticket, grpcCallOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("flight do get: %w", err)
 	}

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -1046,6 +1046,7 @@ func TestMakeHTTPParamsBody(t *testing.T) {
 	}
 }
 
+//nolint:dupl
 func TestWriteWithClientTimeout(t *testing.T) {
 	timeout := 500 * time.Millisecond
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1079,6 +1080,7 @@ func TestWriteWithClientTimeout(t *testing.T) {
 	assert.ErrorContains(t, err, "context deadline exceeded")
 }
 
+//nolint:dupl
 func TestWriteWithClientWriteTimeout(t *testing.T) {
 	timeout := 100 * time.Millisecond
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -1079,6 +1079,39 @@ func TestWriteWithClientTimeout(t *testing.T) {
 	assert.ErrorContains(t, err, "context deadline exceeded")
 }
 
+func TestWriteWithClientWriteTimeout(t *testing.T) {
+	timeout := 100 * time.Millisecond
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(timeout + 1*time.Second)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+	c, err := New(ClientConfig{
+		Host:         ts.URL,
+		Token:        "my-token",
+		Database:     "my-database",
+		WriteTimeout: timeout,
+	})
+	require.NoError(t, err)
+
+	err = c.Write(context.Background(), []byte("data"))
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+
+	p := NewPointWithMeasurement("temp")
+	p.SetTag("location", "harfa")
+	p.SetField("spot", 21.3)
+	err = c.WritePoints(context.Background(), []*Point{p})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+
+	now := time.Now()
+	s := sampleDataStruct(now)
+	err = c.WriteData(context.Background(), []any{s})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "context deadline exceeded")
+}
+
 func TestWriteWithMaxIdleConnections(t *testing.T) {
 	requestCount := 0
 	uniqueConnectionCount := 0


### PR DESCRIPTION
## Proposed Changes

* In `ClientConfig`...
   * Deprecate current property `Timeout`
   * Replace it with `WriteTimeout`, which fulfills the same function
   * Add `QueryTimeout`, 
* Use `QueryTimeout` to create a default `context.WithTimeout()` when opening query streams
* Introduce new Environment Variables 
   * `INFLUX_WRITE_TIMEOUT`
   * `INFLUX_QUERY_TIMEOUT` 
* Tests for the above

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
