### PR TITLE
docs: update basic example with newer timeout parameters.

### DIFF
--- a/examples/Basic/basic.go
+++ b/examples/Basic/basic.go
@@ -30,9 +30,10 @@ func main() {
 		SSLRootsFilePath: sslRootsFilePath,
 		Proxy:            proxyURL,
 		// Connection parameters:
-		Timeout:               timeout,
+		WriteTimeout:          timeout,
 		IdleConnectionTimeout: 90 * time.Second,
 		MaxIdleConnections:    10,
+		QueryTimeout:          2 * time.Minute,
 	}
 	client, err := influxdb3.New(config)
 	if err != nil {


### PR DESCRIPTION
## Proposed Changes

`examples/Basic/basic.go` now features up-to-date timeout parameters and no longer uses deprecated parameter `Timeout`.  

Rebased with force


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated - N.A.
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate - N.A.
- [x] Tests pass  
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
