### PR TITLE
fix: TLS config and flight URL handling

### DIFF
--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -912,46 +912,45 @@ func TestNewServerError(t *testing.T) {
 }
 
 func TestFixUrl(t *testing.T) {
-	boolRef := func(val bool) *bool {
-		b := new(bool)
-		*b = val
-		return b
-	}
-
 	testCases := []*struct {
 		input        string
 		expected     string
-		expectedSafe *bool
+		expectedSafe bool
 	}{
 		{
 			input:        "https://192.168.0.1:85",
 			expected:     "192.168.0.1:85",
-			expectedSafe: boolRef(true),
+			expectedSafe: true,
 		},
 		{
 			input:        "http://192.168.0.1:85",
 			expected:     "192.168.0.1:85",
-			expectedSafe: boolRef(false),
-		},
-		{
-			input:        "192.168.0.1:443",
-			expected:     "192.168.0.1:443",
-			expectedSafe: nil,
-		},
-		{
-			input:        "192.168.0.1:80",
-			expected:     "192.168.0.1:80",
-			expectedSafe: nil,
+			expectedSafe: false,
 		},
 		{
 			input:        "https://192.168.0.1",
 			expected:     "192.168.0.1:443",
-			expectedSafe: boolRef(true),
+			expectedSafe: true,
 		},
 		{
 			input:        "http://192.168.0.1",
 			expected:     "192.168.0.1:80",
-			expectedSafe: boolRef(false),
+			expectedSafe: false,
+		},
+		{
+			input:        "https://192.168.0.5/db",
+			expected:     "192.168.0.5:443/db",
+			expectedSafe: true,
+		},
+		{
+			input:        "http://192.168.0.5/db",
+			expected:     "192.168.0.5:80/db",
+			expectedSafe: false,
+		},
+		{
+			input:        "http://192.168.0.5:8080/db",
+			expected:     "192.168.0.5:8080/db",
+			expectedSafe: false,
 		},
 	}
 
@@ -960,11 +959,7 @@ func TestFixUrl(t *testing.T) {
 			func(t *testing.T) {
 				u, safe := ReplaceURLProtocolWithPort(tc.input)
 				assert.Equal(t, tc.expected, u)
-				if safe == nil || tc.expectedSafe == nil {
-					assert.Equal(t, tc.expectedSafe, safe)
-				} else {
-					assert.Equal(t, *tc.expectedSafe, *safe)
-				}
+				assert.Equal(t, tc.expectedSafe, safe)
 			})
 	}
 }

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -64,6 +64,9 @@ const (
 	defaultIdleConnectionTimeout = 90 * time.Second
 	// defaultMaxIdleConnections specifies the default value of ClientConfig.MaxIdleConnections.
 	defaultMaxIdleConnections = 100
+	// HTTP schemes
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
 )
 
 // ClientConfig holds the parameters for creating a new client.
@@ -167,7 +170,7 @@ func (c *ClientConfig) parse(connectionString string) error {
 		return err
 	}
 
-	if !(u.Scheme == "http" || u.Scheme == "https") {
+	if !(u.Scheme == schemeHTTP || u.Scheme == schemeHTTPS) {
 		return errors.New("only http or https is supported")
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR  allows the use of a custom `tls.Config` set via a custom HTTP Client, used mostly for skipping certificate validation.
Respecting TLS config in the Flight client as well.

Allow passing the URL path to the Flight client. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] A test has been added if appropriate
- [X] Tests pass
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)

