### PR TITLE
chore: upgrade Go to 1.25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
     parameters:
       go-image:
         type: string
-        default: "cimg/go:1.25"
+        default: << pipeline.parameters.default-go-image >>
       exe:
         type: string
         default: docker-amd64-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default-go-image:
     type: string
-    default: "cimg/go:1.24"
+    default: "cimg/go:1.25"
 
 executors:
   docker-amd64-image:
@@ -64,7 +64,7 @@ jobs:
     parameters:
       go-image:
         type: string
-        default: "cimg/go:1.24"
+        default: "cimg/go:1.25"
       exe:
         type: string
         default: docker-amd64-image
@@ -103,9 +103,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            if [[ "$(go env GOVERSION)" == go1.24* ]]; then
-              export GOEXPERIMENT=nocoverageredesign
-            fi
             PKGS=$(go list ./... | grep -Ev '/examples/|/influxdb3/testutil')
             go test -v -race -cover -coverprofile=coverage.out --tags e2e ${PKGS}
       - run:
@@ -145,5 +142,5 @@ workflows:
           matrix:
             parameters:
               exe: [ docker-amd64-image, docker-arm64-image ]
-              go-image: [ << pipeline.parameters.default-go-image >>, "cimg/go:1.25", "cimg/go:1.26" ]
+              go-image: [ << pipeline.parameters.default-go-image >>, "cimg/go:1.26" ]
       - lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@
 2. [#234](https://github.com/InfluxCommunity/influxdb3-go/pull/234): Support partial writes via `AcceptPartial` write option.
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 3. [#238](https://github.com/InfluxCommunity/influxdb3-go/pull/238): Support `arrow.NULL` data type in query response iterator.
-4. [#249](https://github.com/InfluxCommunity/influxdb3-go/pull/249): Requires Go 1.25 or newer.
 
+### Dependencies
+
+1. [#249](https://github.com/InfluxCommunity/influxdb3-go/pull/249): Requires Go 1.25 or newer.
 ## 2.13.0 [2026-02-19]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Dependencies
 
 1. [#249](https://github.com/InfluxCommunity/influxdb3-go/pull/249): Requires Go 1.25 or newer.
+
 ## 2.13.0 [2026-02-19]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 2. [#234](https://github.com/InfluxCommunity/influxdb3-go/pull/234): Support partial writes via `AcceptPartial` write option.
    See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
 3. [#238](https://github.com/InfluxCommunity/influxdb3-go/pull/238): Support `arrow.NULL` data type in query response iterator.
+4. [#249](https://github.com/InfluxCommunity/influxdb3-go/pull/249): Requires Go 1.25 or newer.
 
 ## 2.13.0 [2026-02-19]
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/InfluxCommunity/influxdb3-go/v2
 
 go 1.24.0
 
+toolchain go1.25.0
+
 require (
 	github.com/apache/arrow-go/v18 v18.5.1
 	github.com/google/go-cmp v0.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/InfluxCommunity/influxdb3-go/v2
 
-go 1.24.0
-
-toolchain go1.25.0
+go 1.25.0
 
 require (
 	github.com/apache/arrow-go/v18 v18.5.1

--- a/influxdb3/batching/batcher_test.go
+++ b/influxdb3/batching/batcher_test.go
@@ -151,13 +151,11 @@ func TestThreadSafety(t *testing.T) {
 	)
 
 	for range 25 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 4 {
 				b.Add(&influxdb3.Point{})
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/influxdb3/batching/lp_batcher_test.go
+++ b/influxdb3/batching/lp_batcher_test.go
@@ -249,13 +249,11 @@ func TestLPThreadSafety(t *testing.T) {
 		}))
 
 	for range 25 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 4 {
 				lpb.Add(testString)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
## Proposed Changes

Upgrades minimal Go  version to 1.25. Older version no longer receives security updates and it's blocking upgrades of dependencies (`go-arrow`).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)