### PR TITLE
docs: clarify UseV2Api requirement for writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 2.15.0 [unreleased]
+## 2.14.1 [unreleased]
+
+### Docs
+
+1. [#257](https://github.com/InfluxCommunity/influxdb3-go/pull/257): Clarify `UseV2Api` write guidance for InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless.
 
 ## 2.14.0 [2026-04-23]
 

--- a/README.md
+++ b/README.md
@@ -324,11 +324,12 @@ With InfluxDB Core/Enterprise, when a write request fails due to one or more inv
 
 When partial writes are disabled, any rejected line causes all lines to be rejected.
 
-InfluxDB Clustered does not return this structured partial-write error format.
+InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless use the V2 write
+compatibility endpoint and do not return this structured partial-write error format.
 
-#### Compatibility with InfluxDB Clustered
+#### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
 
-For InfluxDB Clustered, enable `UseV2Api` for writes.
+For InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless, enable `UseV2Api` for writes.
 
 Like other write options, this can be configured in client code, environment variables/connection string (`INFLUX_WRITE_USE_V2_API` / `writeUseV2Api`), or per-write overrides.
 For example:

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -88,6 +88,7 @@ type WriteOptions struct {
 	AcceptPartial bool
 
 	// UseV2Api forces writes to the /api/v2/write compatibility endpoint.
+	// Required for InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless writes.
 	// Default value: false (writes use /api/v3/write_lp).
 	UseV2Api bool
 }
@@ -210,6 +211,7 @@ func WithAcceptPartial(acceptPartial bool) Option {
 
 // WithUseV2Api forces writes to the /api/v2/write compatibility endpoint.
 // In this mode, AcceptPartial is ignored because /api/v2/write does not support accept_partial.
+// This option is required for InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless writes.
 // NoSync is not supported in V2 API and results in a validation error.
 func WithUseV2Api(useV2Api bool) Option {
 	return func(o *options) {

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -70,7 +70,7 @@ type WriteOptions struct {
 	// NoSync=true means faster write but without the confirmation that the data was persisted.
 	//
 	// Note: This option is supported by InfluxDB 3 Core and Enterprise servers only.
-	// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Cloud Serverless/Dedicated)
+	// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Cloud Dedicated/Serverless)
 	// the write operation will fail with an error.
 	//
 	// Default value: false.

--- a/influxdb3/version.go
+++ b/influxdb3/version.go
@@ -27,7 +27,7 @@ import (
 )
 
 // version defines current version
-const version = "2.15.0"
+const version = "2.14.1"
 
 // userAgent header value
 const userAgent = "influxdb3-go/" + version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"


### PR DESCRIPTION
## Proposed Changes

Clarifies write API compatibility docs: `UseV2Api` is required for writes to `InfluxDB Clustered` and **also** `InfluxDB Cloud Dedicated/Serverless`. Updates README guidance and `UseV2Api` code comments for consistency.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)