### PR TITLE
fix: use V2 API for writes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.15.0 [unreleased]
 
+### Bug Fixes
+
+1. [#258](https://github.com/InfluxCommunity/influxdb3-go/pull/258): Restores write behavior changed in 2.14 by defaulting writes to the V2 API endpoint.
+   - All InfluxDB 3 products now work with default write settings.
+   - Write option `NoSync` requires `UseV2Api=false` and the V3 API endpoint. `AcceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored otherwise.
+
 ## 2.14.0 [2026-04-23]
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -326,23 +326,15 @@ When partial writes are disabled, any rejected line causes all lines to be rejec
 
 InfluxDB Clustered does not return this structured partial-write error format.
 
-#### Compatibility with InfluxDB Clustered
+#### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
 
-For InfluxDB Clustered, enable `UseV2Api` for writes.
+Writes use the V2 compatibility endpoint (`/api/v2/write`) by default, so no additional configuration is required for these products.
 
-Like other write options, this can be configured in client code, environment variables/connection string (`INFLUX_WRITE_USE_V2_API` / `writeUseV2Api`), or per-write overrides.
-For example:
+Like other write options, `UseV2Api` can be configured in client code, environment variables/connection string (`INFLUX_WRITE_USE_V2_API` / `writeUseV2Api`), or per-write overrides.
 
-```go
-client, err := influxdb3.New(influxdb3.ClientConfig{
-    Host: "https://your-host",
-    Token: "your-token",
-    WriteOptions: &influxdb3.WriteOptions{UseV2Api: true},
-})
-```
+`NoSync` and `AcceptPartial=false` require the V3-specific write endpoint (`/api/v3/write_lp`), which is available with InfluxDB 3 Core/Enterprise. To use these options, set `UseV2Api=false` (or `WithUseV2Api(false)` per write).
 
-Note: If `UseV2Api` is set, `AcceptPartial` is ignored because this compatibility mode does not support partial-write controls.
-Any rejected line causes all lines to be rejected.
+Note: In V2 compatibility mode, `NoSync=true` and `AcceptPartial=false` return validation errors.
 
 ### Query
 

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ InfluxDB Clustered does not return this structured partial-write error format.
 
 #### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
 
-Writes use the V2 API write endpoint by default, so no additional configuration is required for these products.
+Writes use the V2 API endpoint by default, so no additional configuration is required for these products.
 
 Like other write options, `UseV2Api` can be configured in client code, environment variables/connection string (`INFLUX_WRITE_USE_V2_API` / `writeUseV2Api`), or per-write overrides.
 
-`NoSync` requires the V3 API write endpoint, which is available with InfluxDB 3 Core/Enterprise. `AcceptPartial` applies only to V3 writes and is ignored when using the V2 API write endpoint. To use `NoSync`, set `UseV2Api=false` (or `WithUseV2Api(false)` per write).
+`NoSync` requires the V3 API endpoint, which is available with InfluxDB 3 Core/Enterprise. `AcceptPartial` applies only when writes are sent to the V3 API endpoint and is ignored when using the V2 API endpoint. To use `NoSync`, set `UseV2Api=false` (or `WithUseV2Api(false)` per write).
 
-Note: When writes use the V2 API write endpoint, `NoSync=true` returns a validation error. `AcceptPartial` is not used by this endpoint.
+Note: When writes use the V2 API endpoint, `NoSync=true` returns a validation error. `AcceptPartial` is not used by this endpoint.
 
 ### Query
 

--- a/README.md
+++ b/README.md
@@ -328,13 +328,13 @@ InfluxDB Clustered does not return this structured partial-write error format.
 
 #### Compatibility with InfluxDB Clustered and InfluxDB Cloud Dedicated/Serverless
 
-Writes use the V2 compatibility endpoint (`/api/v2/write`) by default, so no additional configuration is required for these products.
+Writes use the V2 API write endpoint by default, so no additional configuration is required for these products.
 
 Like other write options, `UseV2Api` can be configured in client code, environment variables/connection string (`INFLUX_WRITE_USE_V2_API` / `writeUseV2Api`), or per-write overrides.
 
-`NoSync` and `AcceptPartial=false` require the V3-specific write endpoint (`/api/v3/write_lp`), which is available with InfluxDB 3 Core/Enterprise. To use these options, set `UseV2Api=false` (or `WithUseV2Api(false)` per write).
+`NoSync` requires the V3 API write endpoint, which is available with InfluxDB 3 Core/Enterprise. `AcceptPartial` applies only to V3 writes and is ignored when using the V2 API write endpoint. To use `NoSync`, set `UseV2Api=false` (or `WithUseV2Api(false)` per write).
 
-Note: In V2 compatibility mode, `NoSync=true` and `AcceptPartial=false` return validation errors.
+Note: When writes use the V2 API write endpoint, `NoSync=true` returns a validation error. `AcceptPartial` is not used by this endpoint.
 
 ### Query
 

--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -247,7 +247,7 @@ func setHTTPClientCertPool(httpClient *http.Client, certPool *x509.CertPool, con
 //     (See WriteOptions.NoSync for more details)
 //   - writeAcceptPartial - bool value whether to accept partial writes.
 //     (See WriteOptions.AcceptPartial for more details)
-//   - writeUseV2Api - bool value whether to use V2 compatibility write API.
+//   - writeUseV2Api - bool value whether to use V2 write API.
 //     (See WriteOptions.UseV2Api for more details)
 func NewFromConnectionString(connectionString string) (*Client, error) {
 	cfg := ClientConfig{}
@@ -271,7 +271,7 @@ func NewFromConnectionString(connectionString string) (*Client, error) {
 //     (See WriteOptions.NoSync for more details)
 //   - INFLUX_WRITE_ACCEPT_PARTIAL - bool value whether to accept partial writes
 //     (See WriteOptions.AcceptPartial for more details)
-//   - INFLUX_WRITE_USE_V2_API - bool value whether to use V2 compatibility write API
+//   - INFLUX_WRITE_USE_V2_API - bool value whether to use V2 write API
 //     (See WriteOptions.UseV2Api for more details)
 //   - INFLUX_WRITE_TIMEOUT - duration value (e.g. 10s) to determine how long to wait for a write response
 //   - INFLUX_QUERY_TIMEOUT - duration value (e.g. 10s) applied to queries for calculating a context response Deadline

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -825,6 +825,7 @@ home,room=Sunroom temp=88i 1735545620`
 		{
 			name: "AcceptPartial=true",
 			options: []influxdb3.WriteOption{
+				influxdb3.WithUseV2Api(false),
 				influxdb3.WithAcceptPartial(true),
 			},
 			expectedMessage: `partial write of line protocol occurred:
@@ -847,6 +848,7 @@ home,room=Sunroom temp=88i 1735545620`
 		{
 			name: "AcceptPartial=false",
 			options: []influxdb3.WriteOption{
+				influxdb3.WithUseV2Api(false),
 				influxdb3.WithAcceptPartial(false),
 			},
 			expectedMessage:    "parsing failed for write_lp endpoint",
@@ -875,8 +877,8 @@ home,room=Sunroom temp=88i 1735545620`
 				influxdb3.WithUseV2Api(true),
 				influxdb3.WithAcceptPartial(false),
 			},
-			expectedMessage:    "invalid: write buffer error: line protocol parse failed: invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::string",
-			expectContains:     true,
+			expectedMessage:    "invalid write options: AcceptPartial=false requires UseV2Api=false",
+			expectContains:     false,
 			expectPartialError: false,
 		},
 	}

--- a/influxdb3/client_e2e_test.go
+++ b/influxdb3/client_e2e_test.go
@@ -877,8 +877,8 @@ home,room=Sunroom temp=88i 1735545620`
 				influxdb3.WithUseV2Api(true),
 				influxdb3.WithAcceptPartial(false),
 			},
-			expectedMessage:    "invalid write options: AcceptPartial=false requires UseV2Api=false",
-			expectContains:     false,
+			expectedMessage:    "invalid: write buffer error: line protocol parse failed: invalid column type for column 'temp', expected iox::column_type::field::float, got iox::column_type::field::string",
+			expectContains:     true,
 			expectPartialError: false,
 		},
 	}

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -409,6 +409,7 @@ func TestNewFromConnectionString(t *testing.T) {
 					GzipThreshold: 64,
 					NoSync:        true,
 					AcceptPartial: DefaultWriteOptions.AcceptPartial,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -425,6 +426,7 @@ func TestNewFromConnectionString(t *testing.T) {
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					NoSync:        DefaultWriteOptions.NoSync,
 					AcceptPartial: true,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -457,6 +459,7 @@ func TestNewFromConnectionString(t *testing.T) {
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					Precision:     Second,
 					AcceptPartial: DefaultWriteOptions.AcceptPartial,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -472,6 +475,7 @@ func TestNewFromConnectionString(t *testing.T) {
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					Precision:     Microsecond,
 					AcceptPartial: DefaultWriteOptions.AcceptPartial,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -602,6 +606,7 @@ func TestNewFromEnv(t *testing.T) {
 					GzipThreshold: 64,
 					NoSync:        true,
 					AcceptPartial: DefaultWriteOptions.AcceptPartial,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -624,6 +629,7 @@ func TestNewFromEnv(t *testing.T) {
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					NoSync:        DefaultWriteOptions.NoSync,
 					AcceptPartial: true,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -669,6 +675,7 @@ func TestNewFromEnv(t *testing.T) {
 					GzipThreshold: DefaultWriteOptions.GzipThreshold,
 					NoSync:        DefaultWriteOptions.NoSync,
 					AcceptPartial: DefaultWriteOptions.AcceptPartial,
+					UseV2Api:      DefaultWriteOptions.UseV2Api,
 				},
 			},
 		},
@@ -990,69 +997,69 @@ func TestResolveError(t *testing.T) {
 				"\t\"bad line 1\"\n" +
 				"\t\"bad line 2\"",
 		},
-			{
-				name:        "V3 write error with data field parses as partial",
-				statusCode:  http.StatusBadRequest,
-				contentType: "application/json",
-				responseBody: `{"error":"partial write of line protocol occurred","data":[{"error_message":"A generic parsing error occurred: TakeWhile1",
+		{
+			name:        "V3 write error with data field parses as partial",
+			statusCode:  http.StatusBadRequest,
+			contentType: "application/json",
+			responseBody: `{"error":"partial write of line protocol occurred","data":[{"error_message":"A generic parsing error occurred: TakeWhile1",
 "line_number":2,"original_line":"temperatureroom=room"}]}`,
-				expectedErrMessage: `partial write of line protocol occurred:
+			expectedErrMessage: `partial write of line protocol occurred:
 	line 2: A generic parsing error occurred: TakeWhile1 (temperatureroom=room)`,
-				expectedPartialWriteError: &PartialWriteError{
-					ServerError: ServerError{
-						StatusCode: http.StatusBadRequest,
-					},
-					LineErrors: []PartialWriteLineError{
-						{
-							ErrorMessage: "A generic parsing error occurred: TakeWhile1",
-							LineNumber:   2,
-							OriginalLine: "temperatureroom=room",
-						},
+			expectedPartialWriteError: &PartialWriteError{
+				ServerError: ServerError{
+					StatusCode: http.StatusBadRequest,
+				},
+				LineErrors: []PartialWriteLineError{
+					{
+						ErrorMessage: "A generic parsing error occurred: TakeWhile1",
+						LineNumber:   2,
+						OriginalLine: "temperatureroom=room",
 					},
 				},
 			},
-			{
-				name:        "V3 write error parsing failed write_lp endpoint",
-				statusCode:  http.StatusBadRequest,
-				contentType: "application/json",
-				responseBody: `{"error":"parsing failed for write_lp endpoint","data":[{"error_message":"A generic parsing error occurred: TakeWhile1",
+		},
+		{
+			name:        "V3 write error parsing failed write_lp endpoint",
+			statusCode:  http.StatusBadRequest,
+			contentType: "application/json",
+			responseBody: `{"error":"parsing failed for write_lp endpoint","data":[{"error_message":"A generic parsing error occurred: TakeWhile1",
 "line_number":2,"original_line":"temperatureroom=room"}]}`,
-				expectedErrMessage: "parsing failed for write_lp endpoint:\n\tline 2: " +
-					"A generic parsing error occurred: TakeWhile1 (temperatureroom=room)",
-				expectedPartialWriteError: &PartialWriteError{
-					ServerError: ServerError{
-						StatusCode: http.StatusBadRequest,
-					},
-					LineErrors: []PartialWriteLineError{
-						{
-							ErrorMessage: "A generic parsing error occurred: TakeWhile1",
-							LineNumber:   2,
-							OriginalLine: "temperatureroom=room",
-						},
+			expectedErrMessage: "parsing failed for write_lp endpoint:\n\tline 2: " +
+				"A generic parsing error occurred: TakeWhile1 (temperatureroom=room)",
+			expectedPartialWriteError: &PartialWriteError{
+				ServerError: ServerError{
+					StatusCode: http.StatusBadRequest,
+				},
+				LineErrors: []PartialWriteLineError{
+					{
+						ErrorMessage: "A generic parsing error occurred: TakeWhile1",
+						LineNumber:   2,
+						OriginalLine: "temperatureroom=room",
 					},
 				},
 			},
-			{
-				name:         "V3 write error with typed item missing line details keeps message-only detail",
-				statusCode:   http.StatusBadRequest,
-				contentType:  "application/json",
-				responseBody: `{"error":"partial write of line protocol occurred","data":[{"error_message":"bad line"}]}`,
-				expectedErrMessage: "partial write of line protocol occurred:\n" +
-					"\tbad line",
-				expectedPartialWriteError: &PartialWriteError{
-					ServerError: ServerError{
-						StatusCode: http.StatusBadRequest,
-					},
-					LineErrors: []PartialWriteLineError{
-						{ErrorMessage: "bad line"},
-					},
+		},
+		{
+			name:         "V3 write error with typed item missing line details keeps message-only detail",
+			statusCode:   http.StatusBadRequest,
+			contentType:  "application/json",
+			responseBody: `{"error":"partial write of line protocol occurred","data":[{"error_message":"bad line"}]}`,
+			expectedErrMessage: "partial write of line protocol occurred:\n" +
+				"\tbad line",
+			expectedPartialWriteError: &PartialWriteError{
+				ServerError: ServerError{
+					StatusCode: http.StatusBadRequest,
+				},
+				LineErrors: []PartialWriteLineError{
+					{ErrorMessage: "bad line"},
 				},
 			},
-			{
-				name:               "V3 write error with invalid data string",
-				statusCode:         http.StatusBadRequest,
-				contentType:        "application/json",
-				responseBody:       `{"error":"partial write of line protocol occurred","data":"invalid"}`,
+		},
+		{
+			name:               "V3 write error with invalid data string",
+			statusCode:         http.StatusBadRequest,
+			contentType:        "application/json",
+			responseBody:       `{"error":"partial write of line protocol occurred","data":"invalid"}`,
 			expectedErrMessage: "partial write of line protocol occurred",
 		},
 		{
@@ -1063,25 +1070,25 @@ func TestResolveError(t *testing.T) {
 			expectedErrMessage: "partial write of line protocol occurred:\n" +
 				"\t{\"line_number\":2,\"original_line\":\"bad lp\"}",
 		},
-			{
-				name:               "V3 write error with empty data object",
-				statusCode:         http.StatusBadRequest,
-				contentType:        "application/json",
-				responseBody:       `{"error":"partial write of line protocol occurred","data":{}}`,
-				expectedErrMessage: "partial write of line protocol occurred",
-			},
-			{
-				name:               "V3 write error with null data",
-				statusCode:         http.StatusBadRequest,
-				contentType:        "application/json",
-				responseBody:       `{"error":"partial write of line protocol occurred","data":null}`,
-				expectedErrMessage: "partial write of line protocol occurred",
-			},
-			{
-				name:               "No error message",
-				statusCode:         http.StatusInternalServerError,
-				expectedErrMessage: `500 Internal Server Error`,
-			},
+		{
+			name:               "V3 write error with empty data object",
+			statusCode:         http.StatusBadRequest,
+			contentType:        "application/json",
+			responseBody:       `{"error":"partial write of line protocol occurred","data":{}}`,
+			expectedErrMessage: "partial write of line protocol occurred",
+		},
+		{
+			name:               "V3 write error with null data",
+			statusCode:         http.StatusBadRequest,
+			contentType:        "application/json",
+			responseBody:       `{"error":"partial write of line protocol occurred","data":null}`,
+			expectedErrMessage: "partial write of line protocol occurred",
+		},
+		{
+			name:               "No error message",
+			statusCode:         http.StatusInternalServerError,
+			expectedErrMessage: `500 Internal Server Error`,
+		},
 		{
 			name:               "Plain text response",
 			responseBody:       `error in InfluxQL statement: parsing error: invalid InfluxQL statement at pos 0. Parsing Error: Nom("databases", Fail)`,

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -76,17 +76,18 @@ type WriteOptions struct {
 	// Default value: false.
 	NoSync bool
 
-	// AcceptPartial controls partial-write behavior.
+	// AcceptPartial controls partial-write behavior for writes sent to /api/v3/write_lp
+	// (UseV2Api=false).
 	// Partial writes are enabled with accept_partial=true.
 	// Default value is true to match server default behavior.
 	// The client sends accept_partial=false only when set to false.
 	//
-	// If UseV2Api is true, AcceptPartial=false is invalid because writes are sent to /api/v2/write.
+	// For writes sent to the V2 API write endpoint (UseV2Api=true), this option is not used.
 	//
 	// Default value: true.
 	AcceptPartial bool
 
-	// UseV2Api forces writes to the /api/v2/write compatibility endpoint.
+	// UseV2Api forces writes to the V2 API write endpoint.
 	// Default value: true.
 	UseV2Api bool
 }
@@ -108,9 +109,6 @@ var DefaultWriteOptions = WriteOptions{
 func (o *WriteOptions) validate() error {
 	if o.UseV2Api && o.NoSync {
 		return errors.New("invalid write options: NoSync requires UseV2Api=false")
-	}
-	if o.UseV2Api && !o.AcceptPartial {
-		return errors.New("invalid write options: AcceptPartial=false requires UseV2Api=false")
 	}
 	return nil
 }
@@ -201,17 +199,18 @@ func WithNoSync(noSync bool) Option {
 }
 
 // WithAcceptPartial overrides AcceptPartial in Client.Write methods.
+// This option applies only to writes sent to the V3 API write endpoint (UseV2Api=false).
 // Partial writes are enabled with accept_partial=true.
 // The client sends accept_partial=false only when set to false.
-// AcceptPartial=false requires UseV2Api=false.
 func WithAcceptPartial(acceptPartial bool) Option {
 	return func(o *options) {
 		o.AcceptPartial = acceptPartial
 	}
 }
 
-// WithUseV2Api forces writes to the /api/v2/write compatibility endpoint.
-// In this mode, NoSync and AcceptPartial=false are not supported and result in validation errors.
+// WithUseV2Api forces writes to the V2 API write endpoint.
+// When writes use the V2 API write endpoint, NoSync is not supported and returns a validation error.
+// AcceptPartial is not used for writes sent to the V2 API write endpoint.
 func WithUseV2Api(useV2Api bool) Option {
 	return func(o *options) {
 		o.UseV2Api = useV2Api

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -70,7 +70,7 @@ type WriteOptions struct {
 	// NoSync=true means faster write but without the confirmation that the data was persisted.
 	//
 	// Note: This option is supported by InfluxDB 3 Core and Enterprise servers only.
-	// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Cloud Serverless/Dedicated)
+	// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Cloud Dedicated/Serverless)
 	// the write operation will fail with an error.
 	//
 	// Default value: false.
@@ -81,14 +81,13 @@ type WriteOptions struct {
 	// Default value is true to match server default behavior.
 	// The client sends accept_partial=false only when set to false.
 	//
-	// If UseV2Api is true, this option is ignored and writes are sent to /api/v2/write
-	// (which does not support accept_partial).
+	// If UseV2Api is true, AcceptPartial=false is invalid because writes are sent to /api/v2/write.
 	//
 	// Default value: true.
 	AcceptPartial bool
 
 	// UseV2Api forces writes to the /api/v2/write compatibility endpoint.
-	// Default value: false (writes use /api/v3/write_lp).
+	// Default value: true.
 	UseV2Api bool
 }
 
@@ -103,12 +102,15 @@ var DefaultWriteOptions = WriteOptions{
 	GzipThreshold: 1_000,
 	NoSync:        false,
 	AcceptPartial: true,
-	UseV2Api:      false,
+	UseV2Api:      true,
 }
 
 func (o *WriteOptions) validate() error {
 	if o.UseV2Api && o.NoSync {
-		return errors.New("invalid write options: NoSync cannot be used in V2 API")
+		return errors.New("invalid write options: NoSync requires UseV2Api=false")
+	}
+	if o.UseV2Api && !o.AcceptPartial {
+		return errors.New("invalid write options: AcceptPartial=false requires UseV2Api=false")
 	}
 	return nil
 }
@@ -201,7 +203,7 @@ func WithNoSync(noSync bool) Option {
 // WithAcceptPartial overrides AcceptPartial in Client.Write methods.
 // Partial writes are enabled with accept_partial=true.
 // The client sends accept_partial=false only when set to false.
-// If WithUseV2Api(true) is set, this option is ignored.
+// AcceptPartial=false requires UseV2Api=false.
 func WithAcceptPartial(acceptPartial bool) Option {
 	return func(o *options) {
 		o.AcceptPartial = acceptPartial
@@ -209,8 +211,7 @@ func WithAcceptPartial(acceptPartial bool) Option {
 }
 
 // WithUseV2Api forces writes to the /api/v2/write compatibility endpoint.
-// In this mode, AcceptPartial is ignored because /api/v2/write does not support accept_partial.
-// NoSync is not supported in V2 API and results in a validation error.
+// In this mode, NoSync and AcceptPartial=false are not supported and result in validation errors.
 func WithUseV2Api(useV2Api bool) Option {
 	return func(o *options) {
 		o.UseV2Api = useV2Api

--- a/influxdb3/options.go
+++ b/influxdb3/options.go
@@ -76,18 +76,18 @@ type WriteOptions struct {
 	// Default value: false.
 	NoSync bool
 
-	// AcceptPartial controls partial-write behavior for writes sent to /api/v3/write_lp
+	// AcceptPartial controls partial-write behavior for writes sent to the V3 API endpoint
 	// (UseV2Api=false).
 	// Partial writes are enabled with accept_partial=true.
 	// Default value is true to match server default behavior.
 	// The client sends accept_partial=false only when set to false.
 	//
-	// For writes sent to the V2 API write endpoint (UseV2Api=true), this option is not used.
+	// For writes sent to the V2 API endpoint (UseV2Api=true), this option is not used.
 	//
 	// Default value: true.
 	AcceptPartial bool
 
-	// UseV2Api forces writes to the V2 API write endpoint.
+	// UseV2Api forces writes to the V2 API endpoint.
 	// Default value: true.
 	UseV2Api bool
 }
@@ -199,7 +199,7 @@ func WithNoSync(noSync bool) Option {
 }
 
 // WithAcceptPartial overrides AcceptPartial in Client.Write methods.
-// This option applies only to writes sent to the V3 API write endpoint (UseV2Api=false).
+// This option applies only to writes sent to the V3 API endpoint (UseV2Api=false).
 // Partial writes are enabled with accept_partial=true.
 // The client sends accept_partial=false only when set to false.
 func WithAcceptPartial(acceptPartial bool) Option {
@@ -208,9 +208,9 @@ func WithAcceptPartial(acceptPartial bool) Option {
 	}
 }
 
-// WithUseV2Api forces writes to the V2 API write endpoint.
-// When writes use the V2 API write endpoint, NoSync is not supported and returns a validation error.
-// AcceptPartial is not used for writes sent to the V2 API write endpoint.
+// WithUseV2Api forces writes to the V2 API endpoint.
+// When writes use the V2 API endpoint, NoSync is not supported and returns a validation error.
+// AcceptPartial is not used for writes sent to the V2 API endpoint.
 func WithUseV2Api(useV2Api bool) Option {
 	return func(o *options) {
 		o.UseV2Api = useV2Api

--- a/influxdb3/options_test.go
+++ b/influxdb3/options_test.go
@@ -124,6 +124,7 @@ func TestWriteOptions(t *testing.T) {
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
 				NoSync:        DefaultWriteOptions.NoSync,
 				AcceptPartial: DefaultWriteOptions.AcceptPartial,
+				UseV2Api:      DefaultWriteOptions.UseV2Api,
 			},
 		},
 		{
@@ -135,6 +136,7 @@ func TestWriteOptions(t *testing.T) {
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
 				NoSync:        DefaultWriteOptions.NoSync,
 				AcceptPartial: DefaultWriteOptions.AcceptPartial,
+				UseV2Api:      DefaultWriteOptions.UseV2Api,
 			},
 		},
 		{
@@ -143,6 +145,7 @@ func TestWriteOptions(t *testing.T) {
 				WithDatabase("db-x"),
 				WithPrecision(Millisecond),
 				WithGzipThreshold(4096),
+				WithUseV2Api(false),
 				WithNoSync(true),
 				WithAcceptPartial(true),
 			),
@@ -152,6 +155,7 @@ func TestWriteOptions(t *testing.T) {
 				GzipThreshold: 4096,
 				NoSync:        true,
 				AcceptPartial: true,
+				UseV2Api:      false,
 			},
 		},
 		{
@@ -163,6 +167,7 @@ func TestWriteOptions(t *testing.T) {
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
 				NoSync:        DefaultWriteOptions.NoSync,
 				AcceptPartial: DefaultWriteOptions.AcceptPartial,
+				UseV2Api:      DefaultWriteOptions.UseV2Api,
 			},
 		},
 		{
@@ -173,17 +178,20 @@ func TestWriteOptions(t *testing.T) {
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
 				NoSync:        DefaultWriteOptions.NoSync,
 				AcceptPartial: true,
+				UseV2Api:      DefaultWriteOptions.UseV2Api,
 			},
 		},
 		{
-			name: "override accept partial false",
+			name: "invalid default use v2 api with accept partial false",
 			opts: va(WithAcceptPartial(false)),
 			want: &WriteOptions{
 				Precision:     DefaultWriteOptions.Precision,
 				GzipThreshold: DefaultWriteOptions.GzipThreshold,
 				NoSync:        DefaultWriteOptions.NoSync,
 				AcceptPartial: false,
+				UseV2Api:      true,
 			},
+			err: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
 			name: "invalid use v2 api with no sync",
@@ -195,7 +203,7 @@ func TestWriteOptions(t *testing.T) {
 				AcceptPartial: true,
 				UseV2Api:      true,
 			},
-			err: "invalid write options: NoSync cannot be used in V2 API",
+			err: "invalid write options: NoSync requires UseV2Api=false",
 		},
 		{
 			name: "valid use v2 api with accept partial true",
@@ -209,7 +217,7 @@ func TestWriteOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "valid use v2 api with accept partial false",
+			name: "invalid use v2 api with accept partial false",
 			opts: va(WithUseV2Api(true), WithAcceptPartial(false)),
 			want: &WriteOptions{
 				Precision:     DefaultWriteOptions.Precision,
@@ -218,6 +226,7 @@ func TestWriteOptions(t *testing.T) {
 				AcceptPartial: false,
 				UseV2Api:      true,
 			},
+			err: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
 			name: "invalid use v2 api with no sync true and accept partial false",
@@ -229,7 +238,7 @@ func TestWriteOptions(t *testing.T) {
 				AcceptPartial: false,
 				UseV2Api:      true,
 			},
-			err: "invalid write options: NoSync cannot be used in V2 API",
+			err: "invalid write options: NoSync requires UseV2Api=false",
 		},
 	}
 

--- a/influxdb3/options_test.go
+++ b/influxdb3/options_test.go
@@ -182,7 +182,7 @@ func TestWriteOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid default use v2 api with accept partial false",
+			name: "valid default use v2 api with accept partial false",
 			opts: va(WithAcceptPartial(false)),
 			want: &WriteOptions{
 				Precision:     DefaultWriteOptions.Precision,
@@ -191,7 +191,6 @@ func TestWriteOptions(t *testing.T) {
 				AcceptPartial: false,
 				UseV2Api:      true,
 			},
-			err: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
 			name: "invalid use v2 api with no sync",
@@ -217,7 +216,7 @@ func TestWriteOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid use v2 api with accept partial false",
+			name: "valid use v2 api with accept partial false",
 			opts: va(WithUseV2Api(true), WithAcceptPartial(false)),
 			want: &WriteOptions{
 				Precision:     DefaultWriteOptions.Precision,
@@ -226,7 +225,6 @@ func TestWriteOptions(t *testing.T) {
 				AcceptPartial: false,
 				UseV2Api:      true,
 			},
-			err: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
 			name: "invalid use v2 api with no sync true and accept partial false",

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -230,10 +230,19 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 	resp, err := c.makeAPICall(ctx, *params)
 	if err != nil {
 		var svErr *ServerError
+		if options.UseV2Api && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed &&
+			strings.HasSuffix(params.endpointURL.Path, "/api/v2/write") {
+			return fmt.Errorf(
+				"server doesn't support v2 write API (set UseV2Api=false; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
+				options.UseV2Api,
+				options.NoSync,
+				options.AcceptPartial,
+			)
+		}
 		if !options.UseV2Api && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed &&
 			strings.HasSuffix(params.endpointURL.Path, "/api/v3/write_lp") {
 			return fmt.Errorf(
-				"server doesn't support v3 write API (set WithUseV2Api(true); write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
+				"server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
 				options.UseV2Api,
 				options.NoSync,
 				options.AcceptPartial,

--- a/influxdb3/write.go
+++ b/influxdb3/write.go
@@ -233,7 +233,7 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 		if options.UseV2Api && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed &&
 			strings.HasSuffix(params.endpointURL.Path, "/api/v2/write") {
 			return fmt.Errorf(
-				"server doesn't support v2 write API (set UseV2Api=false; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
+				"server doesn't support the V2 write API endpoint (/api/v2/write) (set UseV2Api=false; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
 				options.UseV2Api,
 				options.NoSync,
 				options.AcceptPartial,
@@ -242,7 +242,7 @@ func (c *Client) write(ctx context.Context, buff []byte, options *WriteOptions) 
 		if !options.UseV2Api && errors.As(err, &svErr) && svErr.StatusCode == http.StatusMethodNotAllowed &&
 			strings.HasSuffix(params.endpointURL.Path, "/api/v3/write_lp") {
 			return fmt.Errorf(
-				"server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
+				"server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:%t,NoSync:%t,AcceptPartial:%t})",
 				options.UseV2Api,
 				options.NoSync,
 				options.AcceptPartial,

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -498,7 +498,7 @@ func TestWriteToV3Server(t *testing.T) {
 				o.UseV2Api = true
 			},
 			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
-			expectedErr: "server doesn't support v2 write API (set UseV2Api=false; write options: {UseV2Api:true,NoSync:false,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V2 write API endpoint (/api/v2/write) (set UseV2Api=false; write options: {UseV2Api:true,NoSync:false,AcceptPartial:true})",
 		},
 	}
 
@@ -568,7 +568,7 @@ func TestWriteToV2Server(t *testing.T) {
 				o.NoSync = false
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
 		},
 		{
 			name: "options UseV2Api true with default AcceptPartial true uses v2 endpoint",
@@ -584,14 +584,14 @@ func TestWriteToV2Server(t *testing.T) {
 				o.NoSync = true
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
 		},
 		{
-			name: "options AcceptPartial false with default v2 mode returns validation error",
+			name: "options AcceptPartial false with default v2 write API uses v2 endpoint",
 			init: func(o *WriteOptions) {
 				o.AcceptPartial = false
 			},
-			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
+			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
 		},
 		{
 			name: "options UseV2Api false with AcceptPartial false routed to v3 and fails on v2-only backend",
@@ -600,15 +600,15 @@ func TestWriteToV2Server(t *testing.T) {
 				o.AcceptPartial = false
 			},
 			correctPath: "/path/api/v3/write_lp?accept_partial=false&db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
 		},
 		{
-			name: "options UseV2Api true with AcceptPartial false returns validation error",
+			name: "options UseV2Api true with AcceptPartial false uses v2 endpoint",
 			init: func(o *WriteOptions) {
 				o.UseV2Api = true
 				o.AcceptPartial = false
 			},
-			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
+			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
 		},
 		{
 			name: "options UseV2Api true with WithAcceptPartial true uses v2 endpoint",
@@ -619,12 +619,12 @@ func TestWriteToV2Server(t *testing.T) {
 			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
 		},
 		{
-			name: "options UseV2Api true with WithAcceptPartial false returns validation error",
+			name: "options UseV2Api true with WithAcceptPartial false uses v2 endpoint",
 			init: func(o *WriteOptions) {
 				o.UseV2Api = true
 			},
 			opts:        []WriteOption{WithAcceptPartial(false)},
-			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
+			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
 		},
 		{
 			name: "options UseV2Api true with WithNoSync true",

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -498,7 +498,8 @@ func TestWriteToV3Server(t *testing.T) {
 				o.UseV2Api = true
 			},
 			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
-			expectedErr: "server doesn't support the V2 write API endpoint (/api/v2/write) (set UseV2Api=false; write options: {UseV2Api:true,NoSync:false,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V2 write API endpoint (/api/v2/write) " +
+				"(set UseV2Api=false; write options: {UseV2Api:true,NoSync:false,AcceptPartial:true})",
 		},
 	}
 
@@ -568,7 +569,8 @@ func TestWriteToV2Server(t *testing.T) {
 				o.NoSync = false
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) " +
+				"(set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
 		},
 		{
 			name: "options UseV2Api true with default AcceptPartial true uses v2 endpoint",
@@ -584,7 +586,8 @@ func TestWriteToV2Server(t *testing.T) {
 				o.NoSync = true
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) " +
+				"(set UseV2Api=true; write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
 		},
 		{
 			name: "options AcceptPartial false with default v2 write API uses v2 endpoint",
@@ -600,7 +603,8 @@ func TestWriteToV2Server(t *testing.T) {
 				o.AcceptPartial = false
 			},
 			correctPath: "/path/api/v3/write_lp?accept_partial=false&db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
+			expectedErr: "server doesn't support the V3 write API endpoint (/api/v3/write_lp) " +
+				"(set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
 		},
 		{
 			name: "options UseV2Api true with AcceptPartial false uses v2 endpoint",

--- a/influxdb3/write_test.go
+++ b/influxdb3/write_test.go
@@ -383,7 +383,7 @@ func compArrays(b1 []byte, b2 []byte) int {
 }
 
 func TestWriteCorrectUrl(t *testing.T) {
-	correctPath := "/path/api/v3/write_lp?db=my-database&org=my-org&precision=millisecond"
+	correctPath := "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// initialization of query client
 		if r.Method == "PRI" {
@@ -492,6 +492,14 @@ func TestWriteToV3Server(t *testing.T) {
 			opts:        []WriteOption{WithAcceptPartial(false)},
 			correctPath: "/path/api/v3/write_lp?accept_partial=false&db=my-database&no_sync=true&org=my-org&precision=millisecond",
 		},
+		{
+			name: "options UseV2Api true routed to v2 and fails on v3-only backend",
+			init: func(o *WriteOptions) {
+				o.UseV2Api = true
+			},
+			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
+			expectedErr: "server doesn't support v2 write API (set UseV2Api=false; write options: {UseV2Api:true,NoSync:false,AcceptPartial:true})",
+		},
 	}
 
 	var correctPath string
@@ -504,6 +512,10 @@ func TestWriteToV3Server(t *testing.T) {
 			t.Fatalf("unexpected request: %s", r.URL.String())
 		}
 		assert.EqualValues(t, correctPath, r.URL.String())
+		if strings.Contains(r.URL.Path, "/api/v2/") {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer ts.Close()
@@ -519,6 +531,7 @@ func TestWriteToV3Server(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			options := DefaultWriteOptions
 			options.Precision = Millisecond
+			options.UseV2Api = false
 			if tc.init != nil {
 				tc.init(&options)
 			}
@@ -551,10 +564,11 @@ func TestWriteToV2Server(t *testing.T) {
 		{
 			name: "options NoSync false routed to v3 and fails on v2-only backend",
 			init: func(o *WriteOptions) {
+				o.UseV2Api = false
 				o.NoSync = false
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set WithUseV2Api(true); write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
+			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:true})",
 		},
 		{
 			name: "options UseV2Api true with default AcceptPartial true uses v2 endpoint",
@@ -566,26 +580,35 @@ func TestWriteToV2Server(t *testing.T) {
 		{
 			name: "options NoSync true routed to v3 and fails on v2-only backend",
 			init: func(o *WriteOptions) {
+				o.UseV2Api = false
 				o.NoSync = true
 			},
 			correctPath: "/path/api/v3/write_lp?db=my-database&no_sync=true&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set WithUseV2Api(true); write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
+			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:true,AcceptPartial:true})",
 		},
 		{
-			name: "options AcceptPartial false routed to v3 and fails on v2-only backend",
+			name: "options AcceptPartial false with default v2 mode returns validation error",
 			init: func(o *WriteOptions) {
 				o.AcceptPartial = false
 			},
-			correctPath: "/path/api/v3/write_lp?accept_partial=false&db=my-database&org=my-org&precision=millisecond",
-			expectedErr: "server doesn't support v3 write API (set WithUseV2Api(true); write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
+			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
-			name: "options UseV2Api true with AcceptPartial false uses v2 endpoint",
+			name: "options UseV2Api false with AcceptPartial false routed to v3 and fails on v2-only backend",
+			init: func(o *WriteOptions) {
+				o.UseV2Api = false
+				o.AcceptPartial = false
+			},
+			correctPath: "/path/api/v3/write_lp?accept_partial=false&db=my-database&org=my-org&precision=millisecond",
+			expectedErr: "server doesn't support v3 write API (set UseV2Api=true; write options: {UseV2Api:false,NoSync:false,AcceptPartial:false})",
+		},
+		{
+			name: "options UseV2Api true with AcceptPartial false returns validation error",
 			init: func(o *WriteOptions) {
 				o.UseV2Api = true
 				o.AcceptPartial = false
 			},
-			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
+			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
 		},
 		{
 			name: "options UseV2Api true with WithAcceptPartial true uses v2 endpoint",
@@ -596,12 +619,20 @@ func TestWriteToV2Server(t *testing.T) {
 			correctPath: "/path/api/v2/write?bucket=my-database&org=my-org&precision=ms",
 		},
 		{
+			name: "options UseV2Api true with WithAcceptPartial false returns validation error",
+			init: func(o *WriteOptions) {
+				o.UseV2Api = true
+			},
+			opts:        []WriteOption{WithAcceptPartial(false)},
+			expectedErr: "invalid write options: AcceptPartial=false requires UseV2Api=false",
+		},
+		{
 			name: "options UseV2Api true with WithNoSync true",
 			init: func(o *WriteOptions) {
 				o.UseV2Api = true
 			},
 			opts:        []WriteOption{WithNoSync(true)},
-			expectedErr: "invalid write options: NoSync cannot be used in V2 API",
+			expectedErr: "invalid write options: NoSync requires UseV2Api=false",
 		},
 		{
 			name: "options UseV2Api true AcceptPartial false and WithNoSync true",
@@ -610,7 +641,7 @@ func TestWriteToV2Server(t *testing.T) {
 				o.AcceptPartial = false
 			},
 			opts:        []WriteOption{WithNoSync(true)},
-			expectedErr: "invalid write options: NoSync cannot be used in V2 API",
+			expectedErr: "invalid write options: NoSync requires UseV2Api=false",
 		},
 	}
 
@@ -757,7 +788,7 @@ func TestWritePointsWithOptions(t *testing.T) {
 		"rack":       "main",
 	}
 	lp := points2bytes(t, points, defaultTags)
-	correctPath := "/api/v3/write_lp?db=db-x&org=&precision=millisecond"
+	correctPath := "/api/v2/write?bucket=db-x&org=&precision=ms"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// initialization of query client
 		if r.Method == "PRI" {
@@ -1023,7 +1054,7 @@ func TestWriteDataWithOptions(t *testing.T) {
 		"rack":       "main",
 	}
 	lp := fmt.Sprintf("air,defaultTag=default,device_id=10,rack=main,sensor=SHT31 humidity=55i,temperature=23.5 %d\n", now.Unix())
-	correctPath := "/api/v3/write_lp?db=db-x&org=my-org&precision=second"
+	correctPath := "/api/v2/write?bucket=db-x&org=my-org&precision=s"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// initialization of query client
 		if r.Method == "PRI" {


### PR DESCRIPTION
Closes #256

## Proposed Changes

This PR restores write compatibility after the behavior change introduced in 2.14, with explicit and intentional endpoint semantics for write options.

### Why these changes were made

  - Users on _InfluxDB Clustered_ and _InfluxDB Cloud Dedicated/Serverless_ were impacted by default V3-write behavior after 2.14.
  - These products use the V2 API write endpoint for writes, so defaulting to the V2 API write endpoint is required for out-of-the-box compatibility.
  - We intentionally preserve access to V3 write behavior via explicit opt-out (`UseV2Api=false`) for users on _InfluxDB 3 Core/Enterprise_.

### Intentional behavior contract

  - Default writes use the V2 API write endpoint.
  - `NoSync` is a V3-only write feature:
      - with V2 writes it fails fast with validation guidance to set `UseV2Api=false`.
  - `AcceptPartial` is only used by V3 writes:
      - with V2 writes it is intentionally ignored (no validation error by value).
  - Guidance errors for endpoint/backend mismatch are intentional and include endpoint details to improve debuggability.

### Notes

  - `AcceptPartial` handling on V2 writes is intentional: it is not treated as an error; it is ignored because the V2 API write endpoint does not use it.
  - `NoSync` fail-fast validation on V2 writes is intentional to prevent unsupported usage from silently proceeding.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)