### PR TITLE
feat: support for IPv6 addresses

### DIFF
--- a/influxdb3/client.go
+++ b/influxdb3/client.go
@@ -235,6 +235,7 @@ func setHTTPClientCertPool(httpClient *http.Client, certPool *x509.CertPool, con
 // NewFromConnectionString creates new Client from the specified connection string.
 // Parameters:
 //   - connectionString: connection string in URL format.
+//     NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
 //
 // Supported query parameters:
 //   - token - authentication token (required)
@@ -260,7 +261,7 @@ func NewFromConnectionString(connectionString string) (*Client, error) {
 
 // NewFromEnv creates new Client instance from environment variables.
 // Supported variables:
-//   - INFLUX_HOST - cloud/server URL (required)
+//   - INFLUX_HOST - cloud/server URL. NOTE: IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1]. (required)
 //   - INFLUX_TOKEN - authentication token (required)
 //   - INFLUX_AUTH_SCHEME - authentication scheme
 //   - INFLUX_ORG - organization name

--- a/influxdb3/client_test.go
+++ b/influxdb3/client_test.go
@@ -331,6 +331,12 @@ func TestURLs(t *testing.T) {
 		{"http://host:8086/path/", "http://host:8086/path/api/"},
 		{"http://host:8086/path1/path2/path3", "http://host:8086/path1/path2/path3/api/"},
 		{"http://host:8086/path1/path2/path3/", "http://host:8086/path1/path2/path3/api/"},
+		{"http://[2001:db8::1]/", "http://[2001:db8::1]/api/"},
+		{"https://[2001:db8:a0b:12f0::1%25eth0]:15000/", "https://[2001:db8:a0b:12f0::1%25eth0]:15000/api/"},
+		{"https://[fe80::1%25eth%250]:15000", "https://[fe80::1%25eth%250]:15000/api/"},
+		{"https://[fe80::1%25eth%200]:15000", "https://[fe80::1%25eth%200]:15000/api/"},
+		// Square brackets will be added automatically, but we're still suggesting users to add square brackets by themselves.
+		{"http://2001:db8::1:8080/", "http://2001:db8::1:8080/api/"},
 	}
 	for _, turl := range urls {
 		t.Run(turl.HostURL, func(t *testing.T) {
@@ -1056,9 +1062,9 @@ func TestResolveError(t *testing.T) {
 			},
 		},
 		{
-			name:        "V3 write error with line_number but no original_line",
-			statusCode:  http.StatusBadRequest,
-			contentType: "application/json",
+			name:         "V3 write error with line_number but no original_line",
+			statusCode:   http.StatusBadRequest,
+			contentType:  "application/json",
 			responseBody: `{"error":"partial write of line protocol occurred","data":[{"error_message":"bad line","line_number":3}]}`,
 			expectedErrMessage: "partial write of line protocol occurred:\n" +
 				"\tline 3: bad line",
@@ -1239,6 +1245,31 @@ func TestFixUrl(t *testing.T) {
 			input:        "http://192.168.0.5:8080/db",
 			expected:     "192.168.0.5:8080/db",
 			expectedSafe: false,
+		},
+		{
+			input:        "http://[2001:db8::1]",
+			expected:     "[2001:db8::1]:80",
+			expectedSafe: false,
+		},
+		{
+			input:        "https://[2001:db8:a0b:12f0::1%25eth0]:15000",
+			expected:     "[2001:db8:a0b:12f0::1%25eth0]:15000",
+			expectedSafe: true,
+		},
+		{
+			input:        "http://2001:db8::1:8080/",
+			expected:     "[2001:db8::1]:8080/",
+			expectedSafe: false,
+		},
+		{
+			input:        "https://[fe80::1%25eth%250]:15000",
+			expected:     "[fe80::1%25eth%250]:15000",
+			expectedSafe: true,
+		},
+		{
+			input:        "https://[fe80::1%25eth%200]:15000",
+			expected:     "[fe80::1%25eth%200]:15000",
+			expectedSafe: true,
 		},
 	}
 

--- a/influxdb3/config.go
+++ b/influxdb3/config.go
@@ -79,6 +79,7 @@ const (
 type ClientConfig struct {
 	// Host holds the URL of the InfluxDB server to connect to.
 	// This must be non-empty. E.g. http://localhost:8086
+	// IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
 	Host string
 
 	// Token holds the authorization token for the API.
@@ -171,6 +172,7 @@ func (c *ClientConfig) validate() error {
 }
 
 // parse initializes the client config from provided connection string.
+// IPv6 must be wrapped inside square brackets, e.g. http://[2001:db8::1].
 func (c *ClientConfig) parse(connectionString string) error {
 	u, err := url.Parse(connectionString)
 	if err != nil {

--- a/influxdb3/fix_url.go
+++ b/influxdb3/fix_url.go
@@ -23,8 +23,9 @@
 package influxdb3
 
 import (
-	"fmt"
+	"net"
 	"net/url"
+	"strings"
 )
 
 // ReplaceURLProtocolWithPort removes the "http://" or "https://" protocol from the given URL and replaces it with the port number.
@@ -43,11 +44,17 @@ import (
 //   - A boolean value indicating the safety of communication (true for safe, false for unsafe) or nil if not detected.
 func ReplaceURLProtocolWithPort(serverURL string) (string, bool) {
 	u, _ := url.Parse(serverURL)
+
+	// When working with IPv6 zone, url.Parse() will change "%25" to "%", so we must get it back.
+	endpoint := net.JoinHostPort(u.Hostname(), port(u))
+	encodedEndpoint := strings.TrimPrefix((&url.URL{Host: endpoint}).String(), "//")
+
 	var safe bool
 	if u.Scheme == schemeHTTPS {
 		safe = true
 	}
-	serverURL = fmt.Sprintf("%s:%s%s", u.Hostname(), port(u), u.Path)
+
+	serverURL = encodedEndpoint + u.Path
 	return serverURL, safe
 }
 


### PR DESCRIPTION
Closes #

## Proposed Changes

- Make `ReplaceURLProtocolWithPort(serverURL string) (string, bool)` working IPv6 addresses.
- Add tests for IPv6, I only check if our clients can parse the addresses correctly. Real communication tests need to be created inside a machine executor in CircleCI, and It is not worth the efforts, already talked with Jakub about this.
- Some observations for Go `net/url` and `net/netip`:
    - When `net/url` and `net/netip` parses URL contain "%25" it will change it to "%", so we must take it back.


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
